### PR TITLE
Fix aggressive UI reloading on mobile Safari

### DIFF
--- a/www/rentmate-ui/src/components/chat/ChatPanel.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatPanel.tsx
@@ -39,7 +39,7 @@ function getModeBadge(task: { mode: TaskMode; participants: { type: string }[] }
 }
 
 export function ChatPanel() {
-  const { chatPanel, closeChat, openChat, suggestions, actionDeskTasks, addChatMessage, updateTaskMessage, setTaskMessages, updateTask, removeTask, updateSuggestionStatus, addDocument, replaceDocument, removeDocument, refreshData } = useApp();
+  const { chatPanel, closeChat, openChat, suggestions, actionDeskTasks, addChatMessage, updateTaskMessage, setTaskMessages, updateTask, removeTask, updateSuggestionStatus, addDocument, replaceDocument, removeDocument, refreshTasksAndSuggestions } = useApp();
   const [dismissConfirm, setDismissConfirm] = useState(false);
   const [dismissing, setDismissing] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
@@ -444,8 +444,8 @@ export function ChatPanel() {
                 }
               }
             }
-            // Refresh data so new suggestions created by agent tools appear
-            refreshData();
+            // Refresh tasks/suggestions so new items created by agent tools appear
+            refreshTasksAndSuggestions();
           } else if (event.type === 'error') {
             activeStreamIdRef.current = null;
             sseError = new Error(event.message ?? 'AI unavailable');

--- a/www/rentmate-ui/src/context/AppContext.tsx
+++ b/www/rentmate-ui/src/context/AppContext.tsx
@@ -1,6 +1,5 @@
 // Entity context management for properties, tenants, and other entities
-import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
 import {
   Suggestion, Property, Tenant, Vendor, MaintenanceTicket, AutonomySettings, ChatMessage, ActionDeskTask, ManagedDocument,
   defaultAutonomySettings,
@@ -67,6 +66,8 @@ interface AppContextType {
   closeChat: () => void;
   setAutonomySettings: (settings: AutonomySettings) => void;
   refreshData: () => void;
+  /** Lightweight refresh: only re-fetches tasks and suggestions. */
+  refreshTasksAndSuggestions: () => void;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -100,15 +101,7 @@ const loadFromStorage = <T,>(key: string, fallback: T): T => {
 };
 
 export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { properties: apiProperties, tenants: apiTenants, vendors: apiVendors, actionDeskTasks: apiActionDeskTasks, tickets: apiTickets, suggestions: apiSuggestions, isLoading: apiLoading, error: apiError, refresh: refreshData } = useApiData();
-
-  // Re-fetch on route navigation
-  const location = useLocation();
-  const isFirstRender = useRef(true);
-  useEffect(() => {
-    if (isFirstRender.current) { isFirstRender.current = false; return; }
-    refreshData();
-  }, [location.pathname]);
+  const { properties: apiProperties, tenants: apiTenants, vendors: apiVendors, actionDeskTasks: apiActionDeskTasks, tickets: apiTickets, suggestions: apiSuggestions, isLoading: apiLoading, error: apiError, refresh: refreshData, refreshTasksAndSuggestions } = useApiData();
 
   // Seed from localStorage so a page reload (e.g. iOS Safari evicting the tab from memory)
   // shows cached data immediately instead of a blank loading state. Dates are coerced back
@@ -318,7 +311,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       chatPanel, entityContext, getEntityContext, setEntityContext,
       updateSuggestionStatus, updateSuggestion, addChatMessage, updateTaskMessage, setTaskMessages, updateTask,
       addTask, removeTask,
-      addProperty, updateProperty, removeProperty, addTenant, addVendor, updateVendor, removeVendor, addDocument, updateDocument, replaceDocument, removeDocument, openChat, closeChat, setAutonomySettings, refreshData,
+      addProperty, updateProperty, removeProperty, addTenant, addVendor, updateVendor, removeVendor, addDocument, updateDocument, replaceDocument, removeDocument, openChat, closeChat, setAutonomySettings, refreshData, refreshTasksAndSuggestions,
     }}>
       {children}
     </AppContext.Provider>

--- a/www/rentmate-ui/src/hooks/useApiData.ts
+++ b/www/rentmate-ui/src/hooks/useApiData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { graphqlQuery, HOUSES_QUERY, TENANTS_QUERY, TASKS_QUERY, VENDORS_QUERY, SUGGESTIONS_QUERY } from '@/data/api';
 import { Property, Tenant, Vendor, ActionDeskTask, MaintenanceTicket, Suggestion, ChatMessage, TaskParticipant } from '@/data/mockData';
 
@@ -12,13 +12,57 @@ interface ApiState {
   isLoading: boolean;
   error: string | null;
   refresh: () => void;
+  /** Lightweight refresh that only re-fetches tasks and suggestions (used after AI chat). */
+  refreshTasksAndSuggestions: () => void;
 }
+
+/** Minimum interval (ms) between consecutive full fetches to prevent rapid-fire reloads. */
+const THROTTLE_MS = 10_000;
 
 export function useApiData(): ApiState {
   const [refreshKey, setRefreshKey] = useState(0);
-  const refresh = useCallback(() => setRefreshKey(k => k + 1), []);
+  /** Tracks whether only tasks/suggestions should be refreshed (vs full). */
+  const partialRefreshRef = useRef(false);
+  const lastFetchAtRef = useRef(0);
+  const throttleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const [state, setState] = useState<Omit<ApiState, 'refresh'>>({
+  const refresh = useCallback(() => {
+    const now = Date.now();
+    const elapsed = now - lastFetchAtRef.current;
+    // If we recently fetched, skip or defer.
+    if (elapsed < THROTTLE_MS) {
+      // Schedule one trailing refresh if not already scheduled
+      if (!throttleTimerRef.current) {
+        throttleTimerRef.current = setTimeout(() => {
+          throttleTimerRef.current = null;
+          partialRefreshRef.current = false;
+          setRefreshKey(k => k + 1);
+        }, THROTTLE_MS - elapsed);
+      }
+      return;
+    }
+    partialRefreshRef.current = false;
+    setRefreshKey(k => k + 1);
+  }, []);
+
+  const refreshTasksAndSuggestions = useCallback(() => {
+    const now = Date.now();
+    const elapsed = now - lastFetchAtRef.current;
+    if (elapsed < THROTTLE_MS) {
+      if (!throttleTimerRef.current) {
+        throttleTimerRef.current = setTimeout(() => {
+          throttleTimerRef.current = null;
+          partialRefreshRef.current = true;
+          setRefreshKey(k => k + 1);
+        }, THROTTLE_MS - elapsed);
+      }
+      return;
+    }
+    partialRefreshRef.current = true;
+    setRefreshKey(k => k + 1);
+  }, []);
+
+  const [state, setState] = useState<Omit<ApiState, 'refresh' | 'refreshTasksAndSuggestions'>>({
     properties: [],
     tenants: [],
     vendors: [],
@@ -41,19 +85,53 @@ export function useApiData(): ApiState {
         hiddenAt = Date.now();
       } else if (document.visibilityState === 'visible') {
         if (hiddenAt !== null && Date.now() - hiddenAt > STALE_MS) {
-          setRefreshKey(k => k + 1);
+          refresh();
         }
         hiddenAt = null;
       }
     };
     document.addEventListener('visibilitychange', handleVisibility);
     return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [refresh]);
+
+  // Clean up throttle timer on unmount
+  useEffect(() => {
+    return () => {
+      if (throttleTimerRef.current) clearTimeout(throttleTimerRef.current);
+    };
   }, []);
 
   useEffect(() => {
     let cancelled = false;
+    const isPartial = partialRefreshRef.current;
 
     async function fetchAll() {
+      lastFetchAtRef.current = Date.now();
+
+      // For partial refreshes, only fetch tasks and suggestions
+      if (isPartial) {
+        const [tasksResult, suggestionsResult] = await Promise.allSettled([
+          graphqlQuery<{ tasks: ApiTask[] }>(TASKS_QUERY),
+          graphqlQuery<{ suggestions: ApiSuggestion[] }>(SUGGESTIONS_QUERY, {}),
+        ]);
+
+        if (cancelled) return;
+
+        const allTasks = tasksResult.status === 'fulfilled' ? (tasksResult.value.tasks || []) : [];
+        const actionDeskTasks: ActionDeskTask[] = allTasks
+          .filter(t => t.taskStatus !== 'dismissed')
+          .map(apiTaskToActionDesk);
+        const tickets: MaintenanceTicket[] = allTasks
+          .filter(t => t.category === 'maintenance')
+          .map(apiTaskToTicket);
+        const suggestions: Suggestion[] = suggestionsResult.status === 'fulfilled'
+          ? (suggestionsResult.value.suggestions || []).map(apiSuggestionToSuggestion)
+          : [];
+
+        setState(prev => ({ ...prev, actionDeskTasks, tickets, suggestions, isLoading: false }));
+        return;
+      }
+
       const [housesResult, tenantsResult, tasksResult, vendorsResult, suggestionsResult] = await Promise.allSettled([
         graphqlQuery<{ houses: ApiHouse[] }>(HOUSES_QUERY),
         graphqlQuery<{ tenants: ApiTenant[] }>(TENANTS_QUERY),
@@ -135,7 +213,7 @@ export function useApiData(): ApiState {
     return () => { cancelled = true; };
   }, [refreshKey]);
 
-  return { ...state, refresh };
+  return { ...state, refresh, refreshTasksAndSuggestions };
 }
 
 


### PR DESCRIPTION
## Summary
- **Remove route-navigation refetch**: Previously, every `location.pathname` change triggered `refreshData()`, firing all 5 GraphQL queries (houses, tenants, tasks, vendors, suggestions) on every page navigation. This was the primary cause of the aggressive reloading, especially painful on iPhone Safari where tab switches also count as navigations.
- **Add 10-second throttle on refresh calls**: Rapid consecutive `refresh()` calls (e.g. from visibility changes, chat completions, or manual triggers) are now collapsed. If a fetch happened within the last 10 seconds, subsequent calls are deferred to a single trailing refresh.
- **Add lightweight `refreshTasksAndSuggestions()`**: After an AI chat response, the ChatPanel now calls this instead of the full `refreshData()`, fetching only tasks and suggestions (2 queries) instead of all 5.

## Decisions made without human input
- **10-second throttle window**: Chose 10 seconds as a reasonable balance between freshness and preventing duplicate fetches. This could be tuned lower (e.g. 5s) for more responsiveness or higher (e.g. 30s) for less network usage.
- **Removed route-change refetch entirely** rather than debouncing it. The data was already fresh from the initial load, and the 5-minute visibility-change handler covers the stale-tab case. If users want fresher data on navigation, a pull-to-refresh or manual refresh button would be a more intentional UX pattern.
- **Kept the existing 5-minute visibility-change stale threshold** unchanged since it was already a reasonable value for background tab refreshes.

## Test plan
- [ ] Navigate between pages rapidly and verify network tab shows no GraphQL fetches on each navigation
- [ ] Send a chat message and confirm only tasks/suggestions queries fire (not houses/tenants/vendors)
- [ ] Switch away from the tab and back within 5 minutes -- no refetch should occur
- [ ] Switch away for >5 minutes and return -- a single refetch should fire
- [ ] Test on iPhone Safari: add to home screen, switch between apps, verify no aggressive reloading

Closes #4