### PR TITLE
Add unit status indicators and per-unit notes

### DIFF
--- a/db/migrations/versions/f9a0b1c2d3e4_add_notes_to_units.py
+++ b/db/migrations/versions/f9a0b1c2d3e4_add_notes_to_units.py
@@ -1,0 +1,24 @@
+"""Add notes column to units table
+
+Revision ID: f9a0b1c2d3e4
+Revises: e7f8a9b0c1d2
+Create Date: 2026-04-06
+
+Allows property managers to store free-text notes per unit (e.g. condition,
+special instructions for the AI agent, appliance details).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'f9a0b1c2d3e4'
+down_revision = 'e7f8a9b0c1d2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('units', sa.Column('notes', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('units', 'notes')

--- a/db/models/rental.py
+++ b/db/models/rental.py
@@ -69,6 +69,7 @@ class Unit(Base):
     )
 
     label = Column(String(100), nullable=False)
+    notes = Column(Text, nullable=True)
 
     __table_args__ = (
         UniqueConstraint(

--- a/gql/schema.py
+++ b/gql/schema.py
@@ -22,6 +22,7 @@ from .types import (
     CreateTaskInput, AddDocumentTagInput, SendMessageInput, UpdateTaskInput,
     CreatePropertyInput, UpdatePropertyInput, CreateTenantWithLeaseInput, AddLeaseForTenantInput,
     VendorType, CreateVendorInput, UpdateVendorInput, VENDOR_TYPES,
+    UnitType, UpdateUnitNotesInput,
 )
 from .services.task_service import TaskService
 from .services import chat_service, suggestion_service
@@ -68,8 +69,25 @@ class Query:
     @strawberry.field(description="Returns all properties with their tenants and leases")
     def houses(self, info) -> typing.List[HouseType]:
         _current_user(info)
+        db = _session(info)
         today = date.today()
-        return [HouseType.from_sql(p, today) for p in fetch_properties(_session(info))]
+        properties = fetch_properties(db)
+        # Compute pending task counts per unit across all properties
+        from sqlalchemy import select as sa_select, func
+        from db.models import Task as TaskModel
+        active_statuses = ('active', 'suggested', 'paused')
+        rows = db.execute(
+            sa_select(TaskModel.unit_id, func.count(TaskModel.id))
+            .where(TaskModel.unit_id.isnot(None))
+            .where(TaskModel.task_status.in_(active_statuses))
+            .group_by(TaskModel.unit_id)
+        ).all()
+        unit_task_map = {r[0]: r[1] for r in rows}
+        for p in properties:
+            p._unit_task_counts = {
+                u.id: unit_task_map.get(u.id, 0) for u in p.units
+            }
+        return [HouseType.from_sql(p, today) for p in properties]
 
     @strawberry.field(description="Returns all tenants with their leases and properties")
     def tenants(self, info) -> typing.List[TenantType]:
@@ -319,6 +337,18 @@ class Mutation(AuthMutation):
         today = date.today()
         prop = PropertyService.update_property(_session(info), input)
         return HouseType.from_sql(prop, today)
+
+    @strawberry.mutation(description="Update notes on a unit")
+    def update_unit_notes(self, info, input: UpdateUnitNotesInput) -> UnitType:
+        _current_user(info)
+        db = _session(info)
+        unit = PropertyService.update_unit_notes(db, input.uid, input.notes)
+        return UnitType(
+            uid=str(unit.id),
+            label=unit.label,
+            is_occupied=False,  # Caller can refetch houses for full status
+            notes=unit.notes,
+        )
 
     @strawberry.mutation(description="Delete a property and all its units/leases (cascade)")
     def delete_property(self, info, uid: str) -> bool:

--- a/gql/services/property_service.py
+++ b/gql/services/property_service.py
@@ -65,6 +65,15 @@ class PropertyService:
         return prop
 
     @staticmethod
+    def update_unit_notes(sess: Session, unit_id: str, notes: str | None) -> SqlUnit:
+        unit = sess.execute(select(SqlUnit).where(SqlUnit.id == unit_id)).scalar_one_or_none()
+        if not unit:
+            raise ValueError(f"Unit {unit_id} not found")
+        unit.notes = notes
+        sess.commit()
+        return unit
+
+    @staticmethod
     def delete_property(sess: Session, uid: str) -> bool:
         prop = sess.execute(select(SqlProperty).where(SqlProperty.id == uid)).scalar_one_or_none()
         if not prop:

--- a/gql/types.py
+++ b/gql/types.py
@@ -129,6 +129,12 @@ class CreatePropertyInput:
     unit_labels: typing.Optional[typing.List[str]] = None
 
 @strawberry.input
+class UpdateUnitNotesInput:
+    uid: str
+    notes: typing.Optional[str] = None
+
+
+@strawberry.input
 class AddLeaseForTenantInput:
     tenant_id: str
     property_id: str
@@ -153,6 +159,10 @@ class UnitType:
     uid: str
     label: str
     is_occupied: bool = False
+    notes: typing.Optional[str] = None
+    tenant_name: typing.Optional[str] = None
+    lease_end_date: typing.Optional[str] = None
+    pending_task_count: int = 0
 
 
 @strawberry.type
@@ -181,7 +191,7 @@ class HouseType:
             units=len(units),
             occupied_units=0,
             monthly_revenue=0.0,
-            unit_list=[UnitType(uid=str(u.id), label=u.label, is_occupied=False) for u in units],
+            unit_list=[UnitType(uid=str(u.id), label=u.label, is_occupied=False, notes=u.notes) for u in units],
         )
 
     @classmethod
@@ -205,8 +215,28 @@ class HouseType:
                 monthly_revenue += l.rent_amount or 0.0
             lease_items.append(LeaseType.from_sql(l))
 
+        # Build per-unit tenant name and lease end date from active leases
+        unit_tenant: dict = {}   # unit_id -> tenant display name
+        unit_lease_end: dict = {}  # unit_id -> lease end date str
+        for l in p.leases:
+            is_active = l.end_date >= today if l.end_date else False
+            if is_active and l.unit_id and l.tenant:
+                unit_tenant[l.unit_id] = tenant_display_name(l.tenant)
+                unit_lease_end[l.unit_id] = str(l.end_date)
+
+        # Count pending tasks per unit (passed in via _unit_task_counts if available)
+        unit_task_counts: dict = getattr(p, '_unit_task_counts', {})
+
         unit_list = [
-            UnitType(uid=str(u.id), label=u.label, is_occupied=u.id in active_unit_ids)
+            UnitType(
+                uid=str(u.id),
+                label=u.label,
+                is_occupied=u.id in active_unit_ids,
+                notes=u.notes,
+                tenant_name=unit_tenant.get(u.id),
+                lease_end_date=unit_lease_end.get(u.id),
+                pending_task_count=unit_task_counts.get(u.id, 0),
+            )
             for u in p.units
         ]
         return cls(

--- a/www/rentmate-ui/src/data/api.ts
+++ b/www/rentmate-ui/src/data/api.ts
@@ -40,7 +40,7 @@ export const HOUSES_QUERY = `
       units
       occupiedUnits
       monthlyRevenue
-      unitList { uid label isOccupied }
+      unitList { uid label isOccupied notes tenantName leaseEndDate pendingTaskCount }
       tenants { uid name }
       leases {
         uid
@@ -81,7 +81,7 @@ export const CREATE_PROPERTY_MUTATION = `
       units
       occupiedUnits
       monthlyRevenue
-      unitList { uid label isOccupied }
+      unitList { uid label isOccupied notes tenantName leaseEndDate pendingTaskCount }
     }
   }
 `;
@@ -365,6 +365,16 @@ export const UPDATE_VENDOR_MUTATION = `
 
 export const DELETE_VENDOR_MUTATION = `
   mutation DeleteVendor($uid: String!) { deleteVendor(uid: $uid) }
+`;
+
+export const UPDATE_UNIT_NOTES_MUTATION = `
+  mutation UpdateUnitNotes($input: UpdateUnitNotesInput!) {
+    updateUnitNotes(input: $input) {
+      uid
+      label
+      notes
+    }
+  }
 `;
 
 export const ASSIGN_VENDOR_TO_TASK_MUTATION = `

--- a/www/rentmate-ui/src/data/mockData.ts
+++ b/www/rentmate-ui/src/data/mockData.ts
@@ -95,6 +95,10 @@ export interface PropertyUnit {
   id: string;
   label: string;
   isOccupied: boolean;
+  notes?: string | null;
+  tenantName?: string | null;
+  leaseEndDate?: string | null;
+  pendingTaskCount?: number;
 }
 
 export interface Property {

--- a/www/rentmate-ui/src/hooks/useApiData.ts
+++ b/www/rentmate-ui/src/hooks/useApiData.ts
@@ -74,7 +74,15 @@ export function useApiData(): ApiState {
             units: h.units ?? 0,
             occupiedUnits: h.occupiedUnits ?? 0,
             monthlyRevenue: h.monthlyRevenue ?? 0,
-            unitList: h.unitList?.map(u => ({ id: u.uid, label: u.label, isOccupied: u.isOccupied })),
+            unitList: h.unitList?.map(u => ({
+              id: u.uid,
+              label: u.label,
+              isOccupied: u.isOccupied,
+              notes: u.notes ?? null,
+              tenantName: u.tenantName ?? null,
+              leaseEndDate: u.leaseEndDate ?? null,
+              pendingTaskCount: u.pendingTaskCount ?? 0,
+            })),
           }))
         : [];
 
@@ -278,6 +286,10 @@ interface ApiHouseUnit {
   uid: string;
   label: string;
   isOccupied: boolean;
+  notes?: string | null;
+  tenantName?: string | null;
+  leaseEndDate?: string | null;
+  pendingTaskCount?: number;
 }
 
 interface ApiHouse {

--- a/www/rentmate-ui/src/pages/PropertyDetail.tsx
+++ b/www/rentmate-ui/src/pages/PropertyDetail.tsx
@@ -5,8 +5,9 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { EntityContextCard, propertyTopics } from '@/components/context/EntityContextCard';
-import { Users, ArrowLeft, MapPin, Bot, Wrench, User, Clock, MessageCircle, Zap, ShieldCheck, Hand, Lock, ChevronRight, Building2, Home, FileText, Trash2, Plus, X, Loader2, Pencil } from 'lucide-react';
-import { graphqlQuery, DELETE_PROPERTY_MUTATION, UPDATE_PROPERTY_MUTATION, CREATE_TENANT_WITH_LEASE_MUTATION, ADD_LEASE_FOR_TENANT_MUTATION } from '@/data/api';
+import { Users, ArrowLeft, MapPin, Bot, Wrench, User, Clock, MessageCircle, Zap, ShieldCheck, Hand, Lock, ChevronRight, Building2, Home, FileText, Trash2, Plus, X, Loader2, Pencil, AlertTriangle, Calendar, Check, StickyNote } from 'lucide-react';
+import { graphqlQuery, DELETE_PROPERTY_MUTATION, UPDATE_PROPERTY_MUTATION, CREATE_TENANT_WITH_LEASE_MUTATION, ADD_LEASE_FOR_TENANT_MUTATION, UPDATE_UNIT_NOTES_MUTATION } from '@/data/api';
+import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -48,6 +49,9 @@ const PropertyDetail = () => {
     firstName: '', lastName: '', email: '', phone: '',
     unitId: '', leaseStart: '', leaseEnd: '', rentAmount: '',
   });
+  const [editingUnitNotes, setEditingUnitNotes] = useState<string | null>(null);
+  const [unitNotesValue, setUnitNotesValue] = useState('');
+  const [savingUnitNotes, setSavingUnitNotes] = useState(false);
 
   useEffect(() => {
     if (!id) return;
@@ -169,6 +173,27 @@ const PropertyDetail = () => {
       toast.error(err instanceof Error ? err.message : 'Failed to add tenant');
     } finally {
       setAddingTenant(false);
+    }
+  };
+
+  const handleSaveUnitNotes = async (unitId: string) => {
+    setSavingUnitNotes(true);
+    try {
+      await graphqlQuery(UPDATE_UNIT_NOTES_MUTATION, {
+        input: { uid: unitId, notes: unitNotesValue || null },
+      });
+      // Update local state
+      updateProperty(id!, {
+        unitList: property?.unitList?.map(u =>
+          u.id === unitId ? { ...u, notes: unitNotesValue || null } : u
+        ),
+      });
+      toast.success('Unit notes saved');
+      setEditingUnitNotes(null);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save notes');
+    } finally {
+      setSavingUnitNotes(false);
     }
   };
 
@@ -310,18 +335,97 @@ const PropertyDetail = () => {
       {!isSingleFamily && property.unitList && property.unitList.length > 0 && (
         <div>
           <h2 className="text-sm font-bold mb-2">Units</h2>
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-            {property.unitList.map(u => (
-              <Card key={u.id} className="p-3 rounded-xl flex items-center gap-2">
-                <Building2 className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div className="min-w-0">
-                  <p className="text-sm font-medium truncate">{u.label}</p>
-                  <p className={`text-[11px] ${u.isOccupied ? 'text-green-600' : 'text-muted-foreground'}`}>
-                    {u.isOccupied ? 'Occupied' : 'Vacant'}
-                  </p>
-                </div>
-              </Card>
-            ))}
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {property.unitList.map(u => {
+              const isEditing = editingUnitNotes === u.id;
+              const leaseEndSoon = u.leaseEndDate
+                ? (new Date(u.leaseEndDate).getTime() - Date.now()) / (1000 * 60 * 60 * 24 * 30) <= 3
+                : false;
+              return (
+                <Card key={u.id} className="p-3 rounded-xl space-y-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <Building2 className="h-4 w-4 text-muted-foreground shrink-0" />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium truncate">{u.label}</p>
+                        <div className="flex items-center gap-1.5 flex-wrap mt-0.5">
+                          <Badge variant="secondary" className={cn('text-[10px] rounded-md gap-0.5',
+                            u.isOccupied ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
+                          )}>
+                            {u.isOccupied ? <Check className="h-2.5 w-2.5" /> : null}
+                            {u.isOccupied ? 'Occupied' : 'Vacant'}
+                          </Badge>
+                          {(u.pendingTaskCount ?? 0) > 0 && (
+                            <Badge variant="secondary" className="text-[10px] rounded-md gap-0.5 bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400">
+                              <AlertTriangle className="h-2.5 w-2.5" />
+                              {u.pendingTaskCount} task{u.pendingTaskCount !== 1 ? 's' : ''}
+                            </Badge>
+                          )}
+                          {u.isOccupied && leaseEndSoon && (
+                            <Badge variant="secondary" className="text-[10px] rounded-md gap-0.5 bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400">
+                              <Calendar className="h-2.5 w-2.5" />
+                              Expiring
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 w-6 p-0 shrink-0"
+                      onClick={() => {
+                        if (isEditing) {
+                          setEditingUnitNotes(null);
+                        } else {
+                          setEditingUnitNotes(u.id);
+                          setUnitNotesValue(u.notes ?? '');
+                        }
+                      }}
+                      title="Edit notes"
+                    >
+                      {isEditing ? <X className="h-3.5 w-3.5" /> : <StickyNote className="h-3.5 w-3.5" />}
+                    </Button>
+                  </div>
+
+                  {/* Tenant and lease info */}
+                  {u.isOccupied && u.tenantName && (
+                    <div className="text-[11px] text-muted-foreground flex items-center gap-1">
+                      <User className="h-3 w-3" />
+                      {u.tenantName}
+                      {u.leaseEndDate && (
+                        <span className="ml-1">
+                          &middot; Lease ends {new Date(u.leaseEndDate).toLocaleDateString()}
+                        </span>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Notes display or edit */}
+                  {isEditing ? (
+                    <div className="space-y-1.5">
+                      <Textarea
+                        className="text-xs min-h-[60px] rounded-lg resize-none"
+                        placeholder="Add notes about this unit (condition, appliances, special instructions)..."
+                        value={unitNotesValue}
+                        onChange={e => setUnitNotesValue(e.target.value)}
+                      />
+                      <div className="flex justify-end gap-1.5">
+                        <Button variant="ghost" size="sm" className="h-6 text-[11px] rounded-md" onClick={() => setEditingUnitNotes(null)}>
+                          Cancel
+                        </Button>
+                        <Button size="sm" className="h-6 text-[11px] rounded-md gap-1" onClick={() => handleSaveUnitNotes(u.id)} disabled={savingUnitNotes}>
+                          {savingUnitNotes && <Loader2 className="h-3 w-3 animate-spin" />}
+                          Save
+                        </Button>
+                      </div>
+                    </div>
+                  ) : u.notes ? (
+                    <p className="text-[11px] text-muted-foreground bg-muted/40 rounded-md px-2 py-1.5 whitespace-pre-wrap">{u.notes}</p>
+                  ) : null}
+                </Card>
+              );
+            })}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

Partial implementation of #9 (Improve UX for managing multi-family units). This PR adds:

- **Unit notes field**: New `notes` text column on the `units` table (with Alembic migration), a `updateUnitNotes` GraphQL mutation, and an inline editor on the property detail page
- **Unit status indicators**: Color-coded badges showing occupied/vacant status, pending task count (red badge), and lease-expiring-soon warning (yellow badge, within 3 months)
- **Richer unit data in API**: `UnitType` now exposes `notes`, `tenantName`, `leaseEndDate`, and `pendingTaskCount` — computed from active leases and open tasks

## Decisions made without human input

- **Unit notes as a plain text field** rather than structured key-value pairs or rich text. A simple text field covers the most common use cases (condition notes, appliance lists, agent instructions) and can be upgraded later without schema changes.
- **Pending task count computed per-query** via a single grouped SQL query on the tasks table, rather than a denormalized counter. This is simpler and avoids stale counts; performance is fine at the expected scale.
- **Lease-expiring-soon threshold set to 3 months**. This matches the existing threshold used elsewhere in the property detail page. Could be made configurable in settings.
- **The `updateUnitNotes` mutation returns a minimal `UnitType`** with `is_occupied=False` — the caller should refetch the full property to get accurate status. This avoids duplicating the lease-checking logic in the mutation path.

## Remaining items from #9

- Unit-level maintenance history (viewing past resolved tasks per unit)
- Bulk unit management (add/remove/rename multiple units at once)
- Unit-specific agent instructions (separate from general notes, fed into the LLM context)

## Test plan

- [x] `poetry run pytest` — 424 passed
- [x] `npx tsc --noEmit` — no type errors
- [ ] Manual: open a multi-family property detail page, verify status badges render
- [ ] Manual: click the notes icon on a unit card, enter text, save, verify it persists
- [ ] Manual: verify units with active tasks show the red task count badge