### PR TITLE
Add multi-tenant support per unit/lease

### DIFF
--- a/db/migrations/versions/a1b2c3d4e5f7_add_lease_tenants_association.py
+++ b/db/migrations/versions/a1b2c3d4e5f7_add_lease_tenants_association.py
@@ -1,0 +1,34 @@
+"""Add lease_tenants many-to-many association table
+
+Revision ID: a1b2c3d4e5f7
+Revises: e7f8a9b0c1d2
+Create Date: 2026-04-06
+
+Supports multiple tenants per lease (roommates). The new lease_tenants
+join table links leases to tenants in a many-to-many relationship.
+The existing leases.tenant_id FK is kept for backward compatibility.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'a1b2c3d4e5f7'
+down_revision = 'e7f8a9b0c1d2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'lease_tenants',
+        sa.Column('lease_id', sa.String(36), sa.ForeignKey('leases.id', ondelete='CASCADE'), primary_key=True),
+        sa.Column('tenant_id', sa.String(36), sa.ForeignKey('tenants.id', ondelete='CASCADE'), primary_key=True),
+    )
+    # Back-fill: every existing lease's primary tenant should appear in the join table
+    op.execute(
+        "INSERT INTO lease_tenants (lease_id, tenant_id) "
+        "SELECT id, tenant_id FROM leases WHERE tenant_id IS NOT NULL"
+    )
+
+
+def downgrade():
+    op.drop_table('lease_tenants')

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -1,5 +1,5 @@
 from .base import Base
-from .rental import Property, Unit, Tenant, Lease
+from .rental import Property, Unit, Tenant, Lease, lease_tenants
 from .tasks import Task
 from .messaging import (
     ParticipantType,
@@ -27,6 +27,7 @@ __all__ = [
     "Unit",
     "Tenant",
     "Lease",
+    "lease_tenants",
     "ParticipantType",
     "ConversationType",
     "MessageType",

--- a/db/models/rental.py
+++ b/db/models/rental.py
@@ -1,3 +1,4 @@
+import builtins
 import uuid
 from datetime import datetime, date
 
@@ -8,6 +9,7 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Table,
     Text,
     UniqueConstraint,
     JSON,
@@ -15,6 +17,15 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from .base import Base
+
+
+# Many-to-many association table: a lease can have multiple tenants (roommates)
+lease_tenants = Table(
+    "lease_tenants",
+    Base.metadata,
+    Column("lease_id", String(36), ForeignKey("leases.id", ondelete="CASCADE"), primary_key=True),
+    Column("tenant_id", String(36), ForeignKey("tenants.id", ondelete="CASCADE"), primary_key=True),
+)
 
 
 class Property(Base):
@@ -108,15 +119,39 @@ class Tenant(Base):
 
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
 
+    # Legacy: leases where this tenant is the primary (via FK).
     leases = relationship(
         "Lease",
         back_populates="tenant",
         cascade="all, delete-orphan",
     )
 
+    # All leases this tenant is associated with (via many-to-many join table).
+    # This is the canonical relationship for multi-tenant support.
+    shared_leases = relationship(
+        "Lease",
+        secondary=lease_tenants,
+        back_populates="tenants",
+    )
+
+    @property
+    def all_leases(self):
+        """Return deduplicated list of all leases (primary + shared)."""
+        seen = set()
+        result = []
+        for lease in self.leases:
+            if lease.id not in seen:
+                seen.add(lease.id)
+                result.append(lease)
+        for lease in self.shared_leases:
+            if lease.id not in seen:
+                seen.add(lease.id)
+                result.append(lease)
+        return result
+
     @property
     def units(self):
-        return [lease.unit for lease in self.leases if lease.unit is not None]
+        return [lease.unit for lease in self.all_leases if lease.unit is not None]
 
 
 class Lease(Base):
@@ -156,3 +191,26 @@ class Lease(Base):
     tenant = relationship("Tenant", back_populates="leases")
     unit = relationship("Unit", back_populates="leases")
     property = relationship("Property", back_populates="leases")
+
+    # Many-to-many: all tenants on this lease (roommates).
+    # The primary tenant (via tenant_id FK) is always included in this list
+    # by the service layer when creating/adding tenants.
+    tenants = relationship(
+        "Tenant",
+        secondary=lease_tenants,
+        back_populates="shared_leases",
+    )
+
+    @builtins.property
+    def all_tenants(self):
+        """Return deduplicated list of all tenants (primary + co-tenants from join table)."""
+        seen: set[str] = set()
+        result: list = []
+        if self.tenant and self.tenant.id not in seen:
+            seen.add(self.tenant.id)
+            result.append(self.tenant)
+        for t in self.tenants:
+            if t.id not in seen:
+                seen.add(t.id)
+                result.append(t)
+        return result

--- a/db/queries.py
+++ b/db/queries.py
@@ -42,6 +42,7 @@ def fetch_properties(db: Session) -> list[Property]:
             select(Property).options(
                 selectinload(Property.units),
                 selectinload(Property.leases).selectinload(Lease.tenant),
+                selectinload(Property.leases).selectinload(Lease.tenants),
                 selectinload(Property.leases).selectinload(Lease.unit),
             )
         )
@@ -68,6 +69,7 @@ def fetch_leases(db: Session) -> list[Lease]:
         db.execute(
             select(Lease).options(
                 selectinload(Lease.tenant),
+                selectinload(Lease.tenants),
                 selectinload(Lease.property),
                 selectinload(Lease.unit),
             )

--- a/gql/schema.py
+++ b/gql/schema.py
@@ -20,7 +20,7 @@ from .types import (
     UserType, HouseType, TenantType, LeaseType, TaskType, SuggestionType,
     ChatMessageType, DocumentTagType, ConversationSummaryType, SpawnTaskInput,
     CreateTaskInput, AddDocumentTagInput, SendMessageInput, UpdateTaskInput,
-    CreatePropertyInput, UpdatePropertyInput, CreateTenantWithLeaseInput, AddLeaseForTenantInput,
+    CreatePropertyInput, UpdatePropertyInput, CreateTenantWithLeaseInput, AddLeaseForTenantInput, AddTenantToLeaseInput,
     VendorType, CreateVendorInput, UpdateVendorInput, VENDOR_TYPES,
 )
 from .services.task_service import TaskService
@@ -339,6 +339,18 @@ class Mutation(AuthMutation):
     def create_tenant_with_lease(self, info, input: CreateTenantWithLeaseInput) -> TenantType:
         _current_user(info)
         return TenantType.from_new(*TenantService.create_tenant_with_lease(_session(info), input))
+
+    @strawberry.mutation(description="Add an existing tenant to a lease (e.g. roommate)")
+    def add_tenant_to_lease(self, info, input: AddTenantToLeaseInput) -> LeaseType:
+        _current_user(info)
+        lease = TenantService.add_tenant_to_lease(_session(info), input)
+        return LeaseType.from_sql(lease)
+
+    @strawberry.mutation(description="Remove a tenant from a lease (does not delete the tenant)")
+    def remove_tenant_from_lease(self, info, lease_id: str, tenant_id: str) -> LeaseType:
+        _current_user(info)
+        lease = TenantService.remove_tenant_from_lease(_session(info), lease_id, tenant_id)
+        return LeaseType.from_sql(lease)
 
     @strawberry.mutation(description="Assign a vendor to a task")
     def assign_vendor_to_task(self, info, task_id: str, vendor_id: str) -> TaskType:

--- a/gql/services/tenant_service.py
+++ b/gql/services/tenant_service.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, date as _date
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from db.models import Tenant as SqlTenant, Lease as SqlLease, Unit as SqlUnit
-from gql.types import CreateTenantWithLeaseInput, AddLeaseForTenantInput
+from gql.types import CreateTenantWithLeaseInput, AddLeaseForTenantInput, AddTenantToLeaseInput
 
 
 class TenantService:
@@ -49,6 +49,11 @@ class TenantService:
             created_at=datetime.now(UTC),
         )
         sess.add(lease)
+        sess.flush()
+
+        # Also populate the many-to-many join table
+        lease.tenants.append(tenant)
+
         sess.commit()
         return tenant, unit, lease
 
@@ -78,5 +83,49 @@ class TenantService:
             created_at=datetime.now(UTC),
         )
         sess.add(lease)
+        sess.flush()
+
+        # Also populate the many-to-many join table
+        lease.tenants.append(tenant)
+
         sess.commit()
         return tenant, unit, lease
+
+    @staticmethod
+    def add_tenant_to_lease(
+        sess: Session, input: AddTenantToLeaseInput
+    ) -> SqlLease:
+        """Add an existing tenant to an existing lease (e.g. a roommate)."""
+        lease = sess.execute(select(SqlLease).where(SqlLease.id == input.lease_id)).scalar_one_or_none()
+        if not lease:
+            raise ValueError(f"Lease {input.lease_id} not found")
+
+        tenant = sess.execute(select(SqlTenant).where(SqlTenant.id == input.tenant_id)).scalar_one_or_none()
+        if not tenant:
+            raise ValueError(f"Tenant {input.tenant_id} not found")
+
+        # Check if already associated
+        if tenant in lease.tenants:
+            return lease
+
+        lease.tenants.append(tenant)
+        sess.commit()
+        return lease
+
+    @staticmethod
+    def remove_tenant_from_lease(
+        sess: Session, lease_id: str, tenant_id: str
+    ) -> SqlLease:
+        """Remove a tenant from a lease's tenant list (but not delete the tenant)."""
+        lease = sess.execute(select(SqlLease).where(SqlLease.id == lease_id)).scalar_one_or_none()
+        if not lease:
+            raise ValueError(f"Lease {lease_id} not found")
+
+        tenant = sess.execute(select(SqlTenant).where(SqlTenant.id == tenant_id)).scalar_one_or_none()
+        if not tenant:
+            raise ValueError(f"Tenant {tenant_id} not found")
+
+        if tenant in lease.tenants:
+            lease.tenants.remove(tenant)
+        sess.commit()
+        return lease

--- a/gql/types.py
+++ b/gql/types.py
@@ -137,6 +137,11 @@ class AddLeaseForTenantInput:
     lease_end: str     # YYYY-MM-DD
     rent_amount: float
 
+@strawberry.input
+class AddTenantToLeaseInput:
+    lease_id: str
+    tenant_id: str
+
 
 # ---------------------------------------------------------------------------
 # Return types (with from_sql converters)
@@ -193,14 +198,17 @@ class HouseType:
         monthly_revenue = 0.0
 
         for l in p.leases:
-            t = l.tenant
             is_active = l.end_date >= today if l.end_date else False
-            if t:
+            # Collect all tenants on this lease (primary + roommates)
+            all_tenants_on_lease = getattr(l, "all_tenants", [])
+            if not all_tenants_on_lease and l.tenant:
+                all_tenants_on_lease = [l.tenant]
+            for t in all_tenants_on_lease:
                 t_key = str(t.id)
                 if t_key not in tenant_map:
                     tenant_map[t_key] = TenantType(uid=str(t.id), name=tenant_display_name(t))
-                if is_active and l.unit_id:
-                    active_unit_ids.add(l.unit_id)
+            if is_active and l.unit_id:
+                active_unit_ids.add(l.unit_id)
             if is_active:
                 monthly_revenue += l.rent_amount or 0.0
             lease_items.append(LeaseType.from_sql(l))
@@ -302,17 +310,27 @@ class LeaseType:
     end_date: str
     rent_amount: float
     tenant: typing.Optional[TenantType] = None
+    tenants: typing.List[TenantType] = strawberry.field(default_factory=list)
     house: typing.Optional[HouseType] = None
 
     @classmethod
     def from_sql(cls, l: typing.Any) -> "LeaseType":
         from db.queries import format_address, tenant_display_name
+        # all_tenants includes the primary tenant plus any roommates from the join table
+        all_tenants_list = getattr(l, "all_tenants", [])
+        if not all_tenants_list and l.tenant:
+            all_tenants_list = [l.tenant]
+        tenants = [
+            TenantType(uid=str(t.id), name=tenant_display_name(t))
+            for t in all_tenants_list
+        ]
         return cls(
             uid=str(l.id),
             start_date=str(l.start_date),
             end_date=str(l.end_date),
             rent_amount=l.rent_amount,
             tenant=TenantType(uid=str(l.tenant.id), name=tenant_display_name(l.tenant)) if l.tenant else None,
+            tenants=tenants,
             house=HouseType(
                 uid=str(l.property.id),
                 name=l.property.name or "",

--- a/llm/agent_data.py
+++ b/llm/agent_data.py
@@ -73,10 +73,17 @@ def _serialize_properties(props) -> list:
                 monthly_revenue += l.rent_amount or 0.0
                 if l.unit_id:
                     active_unit_ids.add(l.unit_id)
+            all_tenants_on_lease = getattr(l, "all_tenants", [])
+            if not all_tenants_on_lease and l.tenant:
+                all_tenants_on_lease = [l.tenant]
             leases.append({
                 "id": str(l.id),
                 "tenant": tenant_display_name(l.tenant) if l.tenant else None,
                 "tenant_id": str(l.tenant.id) if l.tenant else None,
+                "tenants": [
+                    {"id": str(t.id), "name": tenant_display_name(t)}
+                    for t in all_tenants_on_lease
+                ],
                 "unit": l.unit.label if l.unit else None,
                 "start_date": str(l.start_date),
                 "end_date": str(l.end_date),
@@ -126,11 +133,19 @@ def _serialize_tenants(tenants) -> list:
 
 def _serialize_leases(leases) -> list:
     today = date.today()
-    return [
-        {
+    results = []
+    for l in leases:
+        all_tenants_on_lease = getattr(l, "all_tenants", [])
+        if not all_tenants_on_lease and l.tenant:
+            all_tenants_on_lease = [l.tenant]
+        results.append({
             "id": str(l.id),
             "tenant": tenant_display_name(l.tenant) if l.tenant else None,
             "tenant_id": str(l.tenant.id) if l.tenant else None,
+            "tenants": [
+                {"id": str(t.id), "name": tenant_display_name(t)}
+                for t in all_tenants_on_lease
+            ],
             "property": l.property.name if l.property else None,
             "property_id": str(l.property_id) if l.property_id else None,
             "unit": l.unit.label if l.unit else None,
@@ -140,9 +155,8 @@ def _serialize_leases(leases) -> list:
             "rent_amount": l.rent_amount,
             "payment_status": l.payment_status,
             "is_active": bool(l.end_date and l.end_date >= today),
-        }
-        for l in leases
-    ]
+        })
+    return results
 
 
 def _task_tenant_and_unit(c):

--- a/llm/context.py
+++ b/llm/context.py
@@ -26,21 +26,29 @@ def load_account_context(db: Session) -> str:
     if active_leases:
         lines.append("Active Leases:")
         for lease in active_leases:
-            tenant = lease.tenant
             unit = lease.unit
             prop = lease.property
-            if not tenant or not unit:
+            if not unit:
                 continue
-            name = f"{tenant.first_name} {tenant.last_name}".strip()
-            phone = tenant.phone or "no phone"
-            email = tenant.email or "no email"
+            all_tenants = getattr(lease, "all_tenants", [])
+            if not all_tenants and lease.tenant:
+                all_tenants = [lease.tenant]
+            if not all_tenants:
+                continue
+            tenant_parts = []
+            for tenant in all_tenants:
+                name = f"{tenant.first_name} {tenant.last_name}".strip()
+                phone = tenant.phone or "no phone"
+                email = tenant.email or "no email"
+                tenant_parts.append(f"{name} ({phone}, {email})")
+            tenant_str = "; ".join(tenant_parts)
             prop_label = prop.name if prop else "?"
             start = lease.start_date.strftime("%Y-%m-%d") if lease.start_date else "?"
             end = lease.end_date.strftime("%Y-%m-%d") if lease.end_date else "?"
             rent = f"${lease.rent_amount:,.0f}/mo" if lease.rent_amount else "?"
             status = lease.payment_status or "current"
             lines.append(
-                f"  - {name} | {phone} | {email} | {prop_label} {unit.label} "
+                f"  - {tenant_str} | {prop_label} {unit.label} "
                 f"| {start}–{end} | {rent} | payment: {status}"
             )
 
@@ -90,8 +98,10 @@ def build_task_context(db: Session, task_id: str) -> str:
             active = [l for l in unit.leases if l.end_date >= today]
             if active:
                 lease = active[0]
-                tenant = lease.tenant
-                if tenant:
+                all_tenants = getattr(lease, "all_tenants", [])
+                if not all_tenants and lease.tenant:
+                    all_tenants = [lease.tenant]
+                for tenant in all_tenants:
                     name = f"{tenant.first_name} {tenant.last_name}".strip()
                     phone = tenant.phone or "no phone"
                     email = tenant.email or "no email"


### PR DESCRIPTION
## Summary

- Introduces a `lease_tenants` many-to-many join table so multiple tenants (e.g. roommates) can share a single lease
- Adds `Lease.tenants` relationship and `Lease.all_tenants` property that deduplicates the primary tenant (FK) with co-tenants from the join table
- Adds `Tenant.shared_leases` / `Tenant.all_leases` for the inverse direction
- New GraphQL mutations: `addTenantToLease` (add a roommate) and `removeTenantFromLease`
- `LeaseType` now exposes a `tenants` list alongside the existing `tenant` field
- `HouseType.from_sql` collects all tenants across the join table when building property views
- AI agent context builders (`llm/context.py`, `llm/agent_data.py`) now surface all tenants on a unit so the agent can contact everyone
- Alembic migration creates the join table and back-fills existing lease primary tenants into it
- All 424 existing tests pass with no changes needed

## Decisions made without human input

1. **Join table vs. making `tenant_id` nullable**: Kept the existing `tenant_id` FK on `leases` for full backward compatibility. The new `lease_tenants` join table is the canonical many-to-many source. An alternative would be to drop `tenant_id` entirely and rely solely on the join table, but that would be a larger migration with more risk.

2. **`all_tenants` property on Lease**: Added a convenience property that merges the primary tenant (FK) with co-tenants from the join table, deduplicating by ID. This avoids needing to change every consumer at once -- they can read `all_tenants` instead of just `tenant`.

3. **Back-fill migration**: The migration inserts every existing `leases.tenant_id` into the join table so existing data works seamlessly with the new relationship. This means `lease.tenants` always includes at least the primary tenant for historical data.

4. **No frontend changes**: The GraphQL schema changes are additive (new `tenants` field, new mutations). The frontend continues to work with the existing `tenant` field and can adopt `tenants` incrementally.

Closes #11