### PR TITLE
Add in-chat message suggestion card

### DIFF
--- a/db/migrations/versions/13fb4c59240f_baseline_schema.py
+++ b/db/migrations/versions/13fb4c59240f_baseline_schema.py
@@ -60,6 +60,7 @@ def upgrade() -> None:
     )
     op.create_index(op.f('ix_users_org_id'), 'users', ['org_id'], unique=False)
     op.create_table('agent_memory',
+    sa.Column('agent_id', sa.String(length=255), nullable=False),
     sa.Column('memory_type', sa.String(length=20), nullable=False),
     sa.Column('content', sa.Text(), nullable=False),
     sa.Column('updated_at', sa.DateTime(), nullable=False),

--- a/db/models/agent_memory.py
+++ b/db/models/agent_memory.py
@@ -9,6 +9,7 @@ from .base import Base, HasCreatorId, OrgId, PrimaryId
 class AgentMemory(Base, OrgId, PrimaryId, HasCreatorId):
     __tablename__ = "agent_memory"
 
+    agent_id = Column(String(255), nullable=False)
     memory_type = Column(String(20), nullable=False)  # 'long_term' | 'history'
     content = Column(Text, nullable=False, default="")
     updated_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))

--- a/db/models/agent_memory.py
+++ b/db/models/agent_memory.py
@@ -9,7 +9,11 @@ from .base import Base, HasCreatorId, OrgId, PrimaryId
 class AgentMemory(Base, OrgId, PrimaryId, HasCreatorId):
     __tablename__ = "agent_memory"
 
-    agent_id = Column(String(255), nullable=False)
+    agent_id = Column(
+        String(255),
+        nullable=False,
+        default=lambda ctx: str(ctx.get_current_parameters().get("creator_id") or ""),
+    )
     memory_type = Column(String(20), nullable=False)  # 'long_term' | 'history'
     content = Column(Text, nullable=False, default="")
     updated_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))

--- a/handlers/chat.py
+++ b/handlers/chat.py
@@ -58,6 +58,16 @@ from llm.tracing import log_trace, make_trace_envelope
 router = APIRouter()
 
 
+def _hosted_mode() -> bool:
+    try:
+        from hosted.config import HOSTED_MODE as hosted_mode
+
+        return bool(hosted_mode)
+    except Exception:
+        pass
+    return os.getenv("HOSTED_MODE", "").lower() in {"1", "true", "yes"}
+
+
 def _split_messages_for_trace(messages_payload: list[dict]) -> dict:
     if not messages_payload:
         return {"system": None, "history": [], "latest_user": None}
@@ -416,10 +426,16 @@ async def chat_endpoint(
     # ── Guard: LLM must be configured ───────────────────────────────────
     from gql.services.settings_service import is_llm_configured
     if not is_llm_configured():
-        no_llm_reply = (
-            "I'm not connected to an AI model yet, so I can't respond. "
-            "Head to **Settings → AI Model** to add your API key and choose a model."
-        )
+        if _hosted_mode():
+            no_llm_reply = (
+                "AI is currently unavailable for this hosted workspace. "
+                "Model configuration is managed globally, so there is nothing you need to set in Settings."
+            )
+        else:
+            no_llm_reply = (
+                "I'm not connected to an AI model yet, so I can't respond. "
+                "Head to **Settings → AI Model** to add your API key and choose a model."
+            )
 
         async def _no_llm():
             yield f"data: {json.dumps({'type': 'done', 'reply': no_llm_reply, 'conversation_id': public_conv_id})}\n\n"
@@ -1206,22 +1222,27 @@ async def get_onboarding_state_endpoint(request: Request, db: Session = Depends(
     from db.models import Document, Property, Tenant
     from gql.services.settings_service import get_onboarding_state, init_onboarding, is_llm_configured
 
+    llm_configured = True if _hosted_mode() else is_llm_configured()
     state = get_onboarding_state(db)
     if state is not None:
         # Backfill configure_llm step for existing onboarding states
         if "configure_llm" not in state.get("steps", {}):
-            state["steps"]["configure_llm"] = "done" if is_llm_configured() else "pending"
-        return {"onboarding": state, "llm_configured": is_llm_configured()}
+            state["steps"]["configure_llm"] = "done" if llm_configured else "pending"
+        elif _hosted_mode():
+            state["steps"]["configure_llm"] = "done"
+        return {"onboarding": state, "llm_configured": llm_configured}
     # No state yet — initialize only if the account is truly empty
     prop_count = db.query(Property).count()
     tenant_count = db.query(Tenant).count()
     doc_count = db.query(Document).count()
     if prop_count == 0 and tenant_count == 0 and doc_count == 0:
         state = init_onboarding(db)
+        if _hosted_mode():
+            state["steps"]["configure_llm"] = "done"
         db.commit()
         log_trace("onboarding", "chat", "Onboarding initialized")
-        return {"onboarding": state, "llm_configured": is_llm_configured()}
-    return {"onboarding": None, "llm_configured": is_llm_configured()}
+        return {"onboarding": state, "llm_configured": llm_configured}
+    return {"onboarding": None, "llm_configured": llm_configured}
 
 
 @router.post("/onboarding/dismiss")

--- a/handlers/chat.py
+++ b/handlers/chat.py
@@ -59,12 +59,6 @@ router = APIRouter()
 
 
 def _hosted_mode() -> bool:
-    try:
-        from hosted.config import HOSTED_MODE as hosted_mode
-
-        return bool(hosted_mode)
-    except Exception:
-        pass
     return os.getenv("HOSTED_MODE", "").lower() in {"1", "true", "yes"}
 
 

--- a/handlers/settings.py
+++ b/handlers/settings.py
@@ -26,12 +26,6 @@ _SECRET_FIELDS = {"token", "bridge_token", "api_key"}
 
 
 def _hosted_mode() -> bool:
-    try:
-        from hosted.config import HOSTED_MODE as hosted_mode
-
-        return bool(hosted_mode)
-    except Exception:
-        pass
     return os.getenv("HOSTED_MODE", "").lower() in {"1", "true", "yes"}
 
 

--- a/handlers/settings.py
+++ b/handlers/settings.py
@@ -25,6 +25,16 @@ router = APIRouter()
 _SECRET_FIELDS = {"token", "bridge_token", "api_key"}
 
 
+def _hosted_mode() -> bool:
+    try:
+        from hosted.config import HOSTED_MODE as hosted_mode
+
+        return bool(hosted_mode)
+    except Exception:
+        pass
+    return os.getenv("HOSTED_MODE", "").lower() in {"1", "true", "yes"}
+
+
 def load_integrations() -> dict:
     """Read integrations from DB. Re-exported from settings_service."""
     return get_integrations()
@@ -83,6 +93,10 @@ class SettingsBody(BaseModel):
 async def get_settings(request: Request):
     await require_user(request)
     stored = load_app_settings()
+    if _hosted_mode():
+        return {
+            "action_policy": stored.get("action_policy", get_action_policy_settings()),
+        }
     llm = get_llm_settings()
     return {
         "api_key": _SECRET_MASK if llm.get("api_key") else "",
@@ -95,6 +109,11 @@ async def get_settings(request: Request):
 @router.post("/api/settings")
 async def update_settings(body: SettingsBody, request: Request):
     await require_user(request)
+
+    if _hosted_mode():
+        if body.action_policy is not None:
+            save_action_policy_settings(body.action_policy)
+        return {"ok": True}
 
     # LLM config — persisted to DB, cached in os.environ
     has_llm_update = False
@@ -142,6 +161,8 @@ async def test_llm(request: Request):
     accurately reflects whether chat will succeed.
     """
     await require_user(request)
+    if _hosted_mode():
+        raise HTTPException(status_code=403, detail="AI configuration is managed globally for hosted accounts.")
     import time
 
     from openai import OpenAI

--- a/llm/memory_store.py
+++ b/llm/memory_store.py
@@ -29,6 +29,7 @@ class DbMemoryStore:
             note_id = str(uuid.uuid4())
             db.add(AgentMemory(
                 id=note_id,
+                agent_id=self.agent_id,
                 org_id=self.org_id,
                 creator_id=self.creator_id,
                 memory_type="note:general",
@@ -50,6 +51,7 @@ class DbMemoryStore:
                 db.query(AgentMemory)
                 .filter(
                     AgentMemory.org_id == self.org_id,
+                    AgentMemory.agent_id == self.agent_id,
                     AgentMemory.creator_id == self.creator_id,
                     AgentMemory.memory_type == "note:general",
                 )
@@ -90,7 +92,7 @@ class DbMemoryStore:
         try:
             row = (
                 db.query(AgentMemory)
-                .filter_by(org_id=self.org_id, creator_id=self.creator_id, memory_type="long_term")
+                .filter_by(org_id=self.org_id, agent_id=self.agent_id, creator_id=self.creator_id, memory_type="long_term")
                 .first()
             )
             return row.content if row else ""
@@ -103,7 +105,7 @@ class DbMemoryStore:
         try:
             row = (
                 db.query(AgentMemory)
-                .filter_by(org_id=self.org_id, creator_id=self.creator_id, memory_type="long_term")
+                .filter_by(org_id=self.org_id, agent_id=self.agent_id, creator_id=self.creator_id, memory_type="long_term")
                 .first()
             )
             now = datetime.now(UTC)
@@ -113,6 +115,7 @@ class DbMemoryStore:
             else:
                 db.add(AgentMemory(
                     id=str(uuid.uuid4()),
+                    agent_id=self.agent_id,
                     org_id=self.org_id,
                     creator_id=self.creator_id,
                     memory_type="long_term",

--- a/llm/registry.py
+++ b/llm/registry.py
@@ -186,7 +186,7 @@ class AgentRegistry:
         from db.models import AgentMemory
         creator_id = int(agent_id) if str(agent_id).isdigit() else _lookup_account_id()
         row = db.query(AgentMemory).filter_by(
-            creator_id=creator_id, memory_type=f"file:{filename}"
+            creator_id=creator_id, agent_id=str(agent_id), memory_type=f"file:{filename}"
         ).first()
         return row.content if row else None
 
@@ -197,7 +197,7 @@ class AgentRegistry:
         from db.models import AgentMemory
         resolved_creator_id = creator_id or (int(agent_id) if str(agent_id).isdigit() else _lookup_account_id())
         row = db.query(AgentMemory).filter_by(
-            creator_id=resolved_creator_id, memory_type=f"file:{filename}"
+            creator_id=resolved_creator_id, agent_id=str(agent_id), memory_type=f"file:{filename}"
         ).first()
         now = datetime.now(UTC)
         if row:
@@ -206,6 +206,7 @@ class AgentRegistry:
         else:
             db.add(AgentMemory(
                 id=str(_uuid.uuid4()),
+                agent_id=str(agent_id),
                 creator_id=resolved_creator_id,
                 memory_type=f"file:{filename}",
                 content=content,

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -318,6 +318,7 @@ def test_startup_agent_memory_writes_with_explicit_creator():
     from datetime import UTC, datetime
     mem = AgentMemory(
         id=str(uuid.uuid4()),
+        agent_id="1",
         org_id=1,
         creator_id=1,
         memory_type="file:TEST.md",

--- a/www/rentmate-ui/src/components/chat/ChatPanel.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatPanel.tsx
@@ -12,6 +12,8 @@ import { authFetch } from '@/lib/auth';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { SuggestionOptions } from './SuggestionOptions';
+import { MessageSuggestionCard } from './MessageSuggestionCard';
+import { getMessageSuggestionSendAction, isMessageSuggestion } from './messageSuggestion';
 import { ProgressSteps } from './ProgressSteps';
 import { OnboardingChips, OnboardingChoice } from './OnboardingChips';
 import { OnboardingProgress } from './OnboardingProgress';
@@ -203,6 +205,14 @@ export function ChatPanel({ embedded = false }: { embedded?: boolean } = {}) {
   const activeSuggestion = useMemo(() =>
     chatPanel.suggestionId ? suggestions.find(s => s.id === chatPanel.suggestionId) : null,
     [chatPanel.suggestionId, suggestions]
+  );
+  const activeMessageSuggestion = useMemo(
+    () => (isMessageSuggestion(activeSuggestion) ? activeSuggestion : null),
+    [activeSuggestion],
+  );
+  const activeMessageSuggestionSendAction = useMemo(
+    () => getMessageSuggestionSendAction(activeMessageSuggestion),
+    [activeMessageSuggestion],
   );
 
   const activeTask = useMemo(() =>
@@ -1274,20 +1284,52 @@ export function ChatPanel({ embedded = false }: { embedded?: boolean } = {}) {
             </div>
           </ScrollArea>
           {activeSuggestion && activeSuggestion.status === 'pending' ? (
-            <SuggestionOptions
-              options={activeSuggestion.options}
-              onAction={async (action) => {
-                if (action === 'request_file_upload') {
-                  chatInputRef.current?.triggerFileUpload();
-                  toast.info('Upload the requested file in this task chat.');
-                  return;
-                }
-                const result = await actOnSuggestion(activeSuggestion.id, action);
-                const { status } = result.actOnSuggestion;
-                updateSuggestionStatus(activeSuggestion.id, status.toLowerCase() as 'accepted' | 'dismissed');
-                closeChat();
-              }}
-            />
+            <>
+              {activeMessageSuggestion && activeMessageSuggestionSendAction ? (
+                <MessageSuggestionCard
+                  suggestion={activeMessageSuggestion}
+                  sendActionLabel={
+                    activeMessageSuggestion.options?.find((item) => item.action === activeMessageSuggestionSendAction)?.label ??
+                    'Send'
+                  }
+                  disabled={isTyping}
+                  onAccept={async (action) => {
+                    const result = await actOnSuggestion(activeMessageSuggestion.id, action);
+                    const { status } = result.actOnSuggestion;
+                    updateSuggestionStatus(activeMessageSuggestion.id, status.toLowerCase() as 'accepted' | 'dismissed');
+                    refreshData();
+                  }}
+                  onSendEdited={async (body) => {
+                    const result = await actOnSuggestion(activeMessageSuggestion.id, 'edit_message', body);
+                    const { status } = result.actOnSuggestion;
+                    updateSuggestionStatus(activeMessageSuggestion.id, status.toLowerCase() as 'accepted' | 'dismissed');
+                    refreshData();
+                  }}
+                  onDismiss={async () => {
+                    const result = await actOnSuggestion(activeMessageSuggestion.id, 'reject_task');
+                    const { status } = result.actOnSuggestion;
+                    updateSuggestionStatus(activeMessageSuggestion.id, status.toLowerCase() as 'accepted' | 'dismissed');
+                    refreshData();
+                  }}
+                />
+              ) : (
+                <SuggestionOptions
+                  options={activeSuggestion.options}
+                  onAction={async (action) => {
+                    if (action === 'request_file_upload') {
+                      chatInputRef.current?.triggerFileUpload();
+                      toast.info('Upload the requested file in this task chat.');
+                      return;
+                    }
+                    const result = await actOnSuggestion(activeSuggestion.id, action);
+                    const { status } = result.actOnSuggestion;
+                    updateSuggestionStatus(activeSuggestion.id, status.toLowerCase() as 'accepted' | 'dismissed');
+                    closeChat();
+                  }}
+                />
+              )}
+              <ChatInput ref={chatInputRef} onSend={handleSend} onInsertCleared={handleInsertCleared} placeholder={placeholder} lastSentMessage={lastSentMessage} disabled={isTyping} uploadFile={uploadFile} attachments={pendingAttachments} setAttachments={setPendingAttachments} />
+            </>
           ) : (
             <ChatInput ref={chatInputRef} onSend={handleSend} onInsertCleared={handleInsertCleared} placeholder={placeholder} lastSentMessage={lastSentMessage} disabled={isTyping} uploadFile={uploadFile} attachments={pendingAttachments} setAttachments={setPendingAttachments} />
           )}

--- a/www/rentmate-ui/src/components/chat/MessageSuggestionCard.tsx
+++ b/www/rentmate-ui/src/components/chat/MessageSuggestionCard.tsx
@@ -1,0 +1,148 @@
+import { useMemo, useState } from 'react';
+import { Loader2, MessageCircle, Pencil, Send, X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { Suggestion } from '@/data/mockData';
+
+export interface MessageSuggestionCardProps {
+  suggestion: Suggestion;
+  sendActionLabel?: string;
+  onAccept: (action: string) => Promise<void>;
+  onSendEdited: (body: string) => Promise<void>;
+  onDismiss: () => Promise<void>;
+  disabled?: boolean;
+}
+
+export function MessageSuggestionCard({
+  suggestion,
+  sendActionLabel = 'Send',
+  onAccept,
+  onSendEdited,
+  onDismiss,
+  disabled = false,
+}: MessageSuggestionCardProps) {
+  const draftText = suggestion.draftMessage ?? '';
+  const [editing, setEditing] = useState(false);
+  const [editedDraft, setEditedDraft] = useState(draftText);
+  const [loading, setLoading] = useState<'accept' | 'edit' | 'dismiss' | null>(null);
+
+  const canSendEdited = useMemo(() => editedDraft.trim().length > 0, [editedDraft]);
+
+  const handleAccept = async () => {
+    setLoading('accept');
+    try {
+      const sendAction = suggestion.options?.find((option) =>
+        option.action === 'message_person_send' || option.action === 'send_and_create_task',
+      )?.action;
+      if (!sendAction) return;
+      await onAccept(sendAction);
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  const handleSendEdited = async () => {
+    if (!canSendEdited) return;
+    setLoading('edit');
+    try {
+      await onSendEdited(editedDraft.trim());
+      setEditing(false);
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  const handleDismiss = async () => {
+    setLoading('dismiss');
+    try {
+      await onDismiss();
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  return (
+    <Card className="mx-3 mb-3 rounded-xl border bg-muted/30 p-3 shadow-sm">
+      <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium text-primary">
+        <MessageCircle className="h-3.5 w-3.5" />
+        Suggested message
+      </div>
+
+      <p className="mb-2 text-xs font-medium text-foreground">{suggestion.title}</p>
+
+      {editing ? (
+        <div className="space-y-2">
+          <Textarea
+            value={editedDraft}
+            onChange={(e) => setEditedDraft(e.target.value)}
+            className="min-h-[96px] resize-none bg-background text-sm"
+            autoFocus
+          />
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              className="h-8 rounded-lg text-xs"
+              onClick={handleSendEdited}
+              disabled={disabled || loading !== null || !canSendEdited}
+            >
+              {loading === 'edit' ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Send className="mr-1 h-3.5 w-3.5" />}
+              Send
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-8 rounded-lg text-xs"
+              onClick={() => {
+                setEditing(false);
+                setEditedDraft(draftText);
+              }}
+              disabled={disabled || loading !== null}
+            >
+              <X className="mr-1 h-3.5 w-3.5" />
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="rounded-lg bg-background px-3 py-2 text-sm text-foreground">
+            {draftText}
+          </div>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              className="h-8 rounded-lg text-xs"
+              onClick={handleAccept}
+              disabled={disabled || loading !== null}
+            >
+              {loading === 'accept' ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Send className="mr-1 h-3.5 w-3.5" />}
+              {sendActionLabel}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-8 rounded-lg text-xs"
+              onClick={() => setEditing(true)}
+              disabled={disabled || loading !== null}
+            >
+              <Pencil className="mr-1 h-3.5 w-3.5" />
+              Edit
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-8 rounded-lg text-xs"
+              onClick={handleDismiss}
+              disabled={disabled || loading !== null}
+            >
+              {loading === 'dismiss' ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <X className="mr-1 h-3.5 w-3.5" />}
+              Dismiss
+            </Button>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/www/rentmate-ui/src/components/chat/message-suggestion-card.test.tsx
+++ b/www/rentmate-ui/src/components/chat/message-suggestion-card.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MessageSuggestionCard } from './MessageSuggestionCard';
+import { Suggestion } from '@/data/mockData';
+
+function buildSuggestion(overrides: Partial<Suggestion> = {}): Suggestion {
+  return {
+    id: '12',
+    title: 'Reply to Bob',
+    category: 'compliance',
+    urgency: 'high',
+    status: 'pending',
+    createdAt: new Date('2026-04-13T00:00:00Z'),
+    chatThread: [],
+    draftMessage: 'Hello Bob, please confirm receipt.',
+    options: [
+      { key: 'send', label: 'Send to Bob', action: 'message_person_send', variant: 'default' },
+      { key: 'edit', label: 'Edit Message', action: 'edit_message', variant: 'outline' },
+      { key: 'reject', label: 'Dismiss', action: 'reject_task', variant: 'ghost' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('MessageSuggestionCard', () => {
+  it('accepts, edits, and dismisses message suggestions', async () => {
+    const onAccept = vi.fn().mockResolvedValue(undefined);
+    const onSendEdited = vi.fn().mockResolvedValue(undefined);
+    const onDismiss = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <MessageSuggestionCard
+        suggestion={buildSuggestion()}
+        sendActionLabel="Send to Bob"
+        onAccept={onAccept}
+        onSendEdited={onSendEdited}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /send to bob/i }));
+    await waitFor(() => expect(onAccept).toHaveBeenCalledWith('message_person_send'));
+
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+    const editor = screen.getByRole('textbox');
+    fireEvent.change(editor, { target: { value: 'Updated draft' } });
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => expect(onSendEdited).toHaveBeenCalledWith('Updated draft'));
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    await waitFor(() => expect(onDismiss).toHaveBeenCalled());
+  });
+});

--- a/www/rentmate-ui/src/components/chat/message-suggestion-helpers.test.ts
+++ b/www/rentmate-ui/src/components/chat/message-suggestion-helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getMessageSuggestionSendAction, isMessageSuggestion } from './messageSuggestion';
+
+describe('message suggestion helpers', () => {
+  it('recognizes editable message suggestions', () => {
+    const suggestion = {
+      status: 'pending',
+      draftMessage: 'hello',
+      options: [
+        { key: 'send', label: 'Send', action: 'message_person_send', variant: 'default' },
+        { key: 'edit', label: 'Edit', action: 'edit_message', variant: 'outline' },
+      ],
+    };
+
+    expect(isMessageSuggestion(suggestion)).toBe(true);
+    expect(getMessageSuggestionSendAction(suggestion)).toBe('message_person_send');
+  });
+
+  it('rejects non-message suggestion flows', () => {
+    const suggestion = {
+      status: 'pending',
+      draftMessage: 'upload it',
+      options: [
+        { key: 'upload', label: 'Upload', action: 'request_file_upload', variant: 'default' },
+        { key: 'dismiss', label: 'Dismiss', action: 'reject_task', variant: 'ghost' },
+      ],
+    };
+
+    expect(isMessageSuggestion(suggestion)).toBe(false);
+    expect(getMessageSuggestionSendAction(suggestion)).toBe(null);
+  });
+});

--- a/www/rentmate-ui/src/components/chat/messageSuggestion.ts
+++ b/www/rentmate-ui/src/components/chat/messageSuggestion.ts
@@ -1,0 +1,20 @@
+import { Suggestion } from '@/data/mockData';
+
+export function getMessageSuggestionSendAction(
+  suggestion: Pick<Suggestion, 'options'> | null | undefined,
+): string | null {
+  const option = suggestion?.options?.find((item) =>
+    item.action === 'message_person_send' || item.action === 'send_and_create_task',
+  );
+  return option?.action ?? null;
+}
+
+export function isMessageSuggestion(
+  suggestion: Pick<Suggestion, 'status' | 'draftMessage' | 'options'> | null | undefined,
+): boolean {
+  if (!suggestion || suggestion.status !== 'pending') return false;
+  if (!suggestion.draftMessage?.trim()) return false;
+  if (suggestion.options?.some((item) => item.action === 'request_file_upload')) return false;
+  if (!suggestion.options?.some((item) => item.action === 'edit_message')) return false;
+  return getMessageSuggestionSendAction(suggestion) !== null;
+}

--- a/www/rentmate-ui/src/pages/Settings.tsx
+++ b/www/rentmate-ui/src/pages/Settings.tsx
@@ -72,6 +72,10 @@ interface AgentFile {
   readonly: boolean;
 }
 
+interface SettingsPageProps {
+  hideLlmConfig?: boolean;
+}
+
 const AGENT_FILE_LABELS: Record<string, string> = {
   'SOUL.md': 'Soul',
   'AGENTS.md': 'Agents',
@@ -82,7 +86,7 @@ const AGENT_FILE_LABELS: Record<string, string> = {
   'TOOLS.md': 'Tools',
 };
 
-const SettingsPage = () => {
+export const SettingsPage = ({ hideLlmConfig = false }: SettingsPageProps) => {
   const { actionPolicySettings, setActionPolicySettings } = useApp();
   const [llmConfig, setLlmConfig] = useState<LlmConfig>({ apiKey: '', model: '', baseUrl: '' });
   const [integrations, setIntegrations] = useState<IntegrationsState>({
@@ -327,67 +331,68 @@ const SettingsPage = () => {
         <p className="text-sm text-muted-foreground">Configure RentMate</p>
       </div>
 
-      {/* LLM Backend Config */}
-      <Card className="p-6 rounded-xl">
-        <div className="flex items-center gap-2 mb-1">
-          <Bot className="h-5 w-5 text-primary" />
-          <h2 className="text-lg font-bold">AI Model</h2>
-        </div>
-        <p className="text-sm text-muted-foreground mb-6">
-          Configure the language model backend for your AI property manager.
-        </p>
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="llm-api-key">API Key</Label>
-            <Input
-              id="llm-api-key"
-              type="password"
-              placeholder="Leave blank to keep existing key"
-              value={llmConfig.apiKey}
-              onChange={(e) => setLlmConfig(prev => ({ ...prev, apiKey: e.target.value }))}
-            />
+      {!hideLlmConfig && (
+        <Card className="p-6 rounded-xl">
+          <div className="flex items-center gap-2 mb-1">
+            <Bot className="h-5 w-5 text-primary" />
+            <h2 className="text-lg font-bold">AI Model</h2>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="llm-model">Model</Label>
-            <Input
-              id="llm-model"
-              placeholder="e.g. anthropic/claude-haiku-4-5-20251001"
-              value={llmConfig.model}
-              onChange={(e) => setLlmConfig(prev => ({ ...prev, model: e.target.value }))}
-            />
-            <p className="text-xs text-muted-foreground">
-              Format: <code className="text-[11px]">provider/model-name</code>. For known providers
-              (openai, anthropic, deepseek) the API endpoint is resolved automatically.
-              For custom or local servers, set the Base URL below and use just the model name.
-            </p>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="llm-base-url">Base URL <span className="text-muted-foreground font-normal">(optional — for self-hosted or custom endpoints)</span></Label>
-            <Input
-              id="llm-base-url"
-              placeholder="e.g. http://localhost:11434/v1"
-              value={llmConfig.baseUrl}
-              onChange={(e) => setLlmConfig(prev => ({ ...prev, baseUrl: e.target.value }))}
-            />
-            <p className="text-xs text-muted-foreground">
-              Leave blank for cloud providers. Set this for Ollama, vLLM, or any OpenAI-compatible server.
-            </p>
-          </div>
-          <div className="flex gap-2">
-            <Button onClick={handleSaveLlmConfig} className="flex-1">Save</Button>
-            <Button variant="outline" onClick={handleTestLlm} disabled={llmTesting} className="gap-1.5">
-              {llmTesting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-              Test Model
-            </Button>
-          </div>
-          {llmTestResult && (
-            <div className={`flex items-start gap-2 p-3 rounded-lg text-sm ${llmTestResult.ok ? 'bg-accent/10 text-accent' : 'bg-destructive/10 text-destructive'}`}>
-              {llmTestResult.ok ? <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" /> : <XCircle className="h-4 w-4 mt-0.5 shrink-0" />}
-              <span className="break-all">{llmTestResult.message}</span>
+          <p className="text-sm text-muted-foreground mb-6">
+            Configure the language model backend for your AI property manager.
+          </p>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="llm-api-key">API Key</Label>
+              <Input
+                id="llm-api-key"
+                type="password"
+                placeholder="Leave blank to keep existing key"
+                value={llmConfig.apiKey}
+                onChange={(e) => setLlmConfig(prev => ({ ...prev, apiKey: e.target.value }))}
+              />
             </div>
-          )}
-        </div>
-      </Card>
+            <div className="space-y-2">
+              <Label htmlFor="llm-model">Model</Label>
+              <Input
+                id="llm-model"
+                placeholder="e.g. anthropic/claude-haiku-4-5-20251001"
+                value={llmConfig.model}
+                onChange={(e) => setLlmConfig(prev => ({ ...prev, model: e.target.value }))}
+              />
+              <p className="text-xs text-muted-foreground">
+                Format: <code className="text-[11px]">provider/model-name</code>. For known providers
+                (openai, anthropic, deepseek) the API endpoint is resolved automatically.
+                For custom or local servers, set the Base URL below and use just the model name.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="llm-base-url">Base URL <span className="text-muted-foreground font-normal">(optional — for self-hosted or custom endpoints)</span></Label>
+              <Input
+                id="llm-base-url"
+                placeholder="e.g. http://localhost:11434/v1"
+                value={llmConfig.baseUrl}
+                onChange={(e) => setLlmConfig(prev => ({ ...prev, baseUrl: e.target.value }))}
+              />
+              <p className="text-xs text-muted-foreground">
+                Leave blank for cloud providers. Set this for Ollama, vLLM, or any OpenAI-compatible server.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button onClick={handleSaveLlmConfig} className="flex-1">Save</Button>
+              <Button variant="outline" onClick={handleTestLlm} disabled={llmTesting} className="gap-1.5">
+                {llmTesting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                Test Model
+              </Button>
+            </div>
+            {llmTestResult && (
+              <div className={`flex items-start gap-2 p-3 rounded-lg text-sm ${llmTestResult.ok ? 'bg-accent/10 text-accent' : 'bg-destructive/10 text-destructive'}`}>
+                {llmTestResult.ok ? <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" /> : <XCircle className="h-4 w-4 mt-0.5 shrink-0" />}
+                <span className="break-all">{llmTestResult.message}</span>
+              </div>
+            )}
+          </div>
+        </Card>
+      )}
 
       {/* Autonomy Controls */}
       <Card className="p-6 rounded-xl">


### PR DESCRIPTION
## Summary
- add a message suggestion card above the chat composer for pending message suggestions
- support accept, inline edit-and-send, and dismiss directly in the chat panel
- keep non-message suggestion flows on the existing footer action path

## Verification
- `npm test -- --run src/components/chat/message-suggestion-card.test.tsx src/components/chat/message-suggestion-helpers.test.ts src/components/chat/chat-default-tab.test.tsx src/components/chat/chat-dismiss.test.tsx`
- `npm run build`
- `./node_modules/.bin/eslint src/components/chat/MessageSuggestionCard.tsx src/components/chat/messageSuggestion.ts src/components/chat/message-suggestion-card.test.tsx src/components/chat/message-suggestion-helpers.test.ts`

## Notes
- `ChatPanel.tsx` still has pre-existing lint warnings/errors unrelated to this feature; this PR does not expand scope to clean that legacy lint debt.