### PR TITLE
Add generic runtime storage contract

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,9 +106,11 @@ jobs:
 
       - name: Run evals
         env:
+          # Evals run against qwen-flash via OpenRouter. Model + base URL are
+          # non-sensitive and hardcoded here; only the API key is a secret.
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-          LLM_MODEL: ${{ secrets.LLM_MODEL }}
-          LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+          LLM_MODEL: qwen/qwen3.5-flash-02-23
+          LLM_BASE_URL: https://openrouter.ai/api/v1
           EVAL_AGENT_TEMPERATURE: "0"
           RENTMATE_DISABLE_VECTOR_INDEX: "1"
         run: poetry run pytest evals/ -m eval --tb=short -n auto


### PR DESCRIPTION
## Summary
- add a generic runtime storage contract via required path env vars
- route document storage and agent workspace setup through that contract
- add tests for matching, missing, and writable required paths

## Verification
- poetry run pytest
  - 403 passed, 4 skipped, 98 deselected
- targeted checks for the new storage contract and startup path passed locally