### PR TITLE
Shrink backend Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,58 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.12-slim
+FROM python:3.12-slim AS python-base
 
-# System dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends curl build-essential git && rm -rf /var/lib/apt/lists/*
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    POETRY_VIRTUALENVS_CREATE=false \
+    POETRY_NO_INTERACTION=1
 
-# Install Poetry
-ENV POETRY_VERSION=1.8.2
+FROM python-base AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV POETRY_VERSION=2.3.3
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:$PATH"
-ENV POETRY_VIRTUALENVS_CREATE=false
-ENV POETRY_NO_INTERACTION=1
-ENV PIP_NO_CACHE_DIR=1
 
-# Set workdir
 WORKDIR /app
 
-# Copy files
 COPY pyproject.toml poetry.lock* ./
 
-# Install dependencies
-RUN poetry install --no-root --only main
+RUN poetry install --no-root --only main \
+    && find /usr/local/lib/python3.12/site-packages -type d \( -name test -o -name tests \) -prune -exec rm -rf '{}' + \
+    && rm -rf /usr/local/bin/pip* /usr/local/lib/python3.12/site-packages/pip* /root/.cache
 
-# Install shared libraries for WeasyPrint HTML->PDF rendering
+FROM python-base AS runtime
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    fonts-dejavu-core \
     libcairo2 \
     libgdk-pixbuf-2.0-0 \
     libpango-1.0-0 \
     libpangoft2-1.0-0 \
     libpangocairo-1.0-0 \
     shared-mime-info \
-    fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /usr/local /usr/local
 
 COPY alembic.ini ./
 COPY main.py ./
-COPY agents ./agents
+COPY memory_watchdog.py ./
 COPY backends ./backends
 COPY db ./db
 COPY gql ./gql
 COPY handlers ./handlers
 COPY llm ./llm
+COPY rentmate ./rentmate
 
-# Expose port and run uvicorn
 EXPOSE 8000
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--log-level", "debug"]

--- a/infra/backend.Dockerfile
+++ b/infra/backend.Dockerfile
@@ -1,49 +1,59 @@
 # Backend Dockerfile
-FROM python:3.12-slim
+FROM python:3.12-slim AS python-base
 
-# System dependencies
-# We need build-essential for packages like fastuuid that require a C linker
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    POETRY_VIRTUALENVS_CREATE=false \
+    POETRY_NO_INTERACTION=1
+
+FROM python-base AS builder
+
+# Build-only dependencies. Wheels are copied into the runtime stage.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
     build-essential \
+    curl \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Poetry
-ENV POETRY_VERSION=1.8.2
+ENV POETRY_VERSION=2.3.3
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:$PATH"
-ENV POETRY_VIRTUALENVS_CREATE=false
-ENV POETRY_NO_INTERACTION=1
-ENV PIP_NO_CACHE_DIR=1
 
 WORKDIR /app
 
-# Copy dependency files
 COPY pyproject.toml poetry.lock* ./
 
-# Install Python dependencies, including dev tools for containerized local testing
-RUN poetry install --no-root
+RUN poetry install --no-root --only main \
+    && find /usr/local/lib/python3.12/site-packages -type d \( -name test -o -name tests \) -prune -exec rm -rf '{}' + \
+    && rm -rf /usr/local/bin/pip* /usr/local/lib/python3.12/site-packages/pip* /root/.cache
 
-# Install shared libraries for WeasyPrint HTML->PDF rendering
+FROM python-base AS runtime
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    fonts-dejavu-core \
     libcairo2 \
     libgdk-pixbuf-2.0-0 \
     libpango-1.0-0 \
     libpangoft2-1.0-0 \
     libpangocairo-1.0-0 \
     shared-mime-info \
-    fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /usr/local /usr/local
 
 # Copy only runtime backend files to preserve build cache and avoid frontend/test churn
 COPY alembic.ini ./
 COPY main.py ./
+COPY memory_watchdog.py ./
 COPY backends ./backends
 COPY db ./db
 COPY gql ./gql
 COPY handlers ./handlers
 COPY llm ./llm
+COPY rentmate ./rentmate
 
 # Environment variable for dev
 ENV RENTMATE_ENV=development

--- a/memory_watchdog.py
+++ b/memory_watchdog.py
@@ -11,8 +11,12 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
-import memray
+try:
+    import memray
+except ImportError:  # pragma: no cover - exercised only in slim runtime images
+    memray = None
 
 _logger = logging.getLogger("rentmate.memory_watchdog")
 
@@ -59,7 +63,7 @@ def _monitor_loop(
 ) -> None:
     """Blocking loop — meant to run in a daemon thread."""
     warning_threshold = int(rss_limit_bytes * _WARNING_RATIO)
-    tracker: memray.Tracker | None = None
+    tracker: Any | None = None
     tracker_path: Path | None = None
     check_count = 0
 
@@ -97,7 +101,7 @@ def _monitor_loop(
                 os._exit(1)
 
             # --- warning phase: start tracking ---
-            if rss > warning_threshold and tracker is None:
+            if rss > warning_threshold and tracker is None and memray is not None:
                 ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
                 tracker_path = Path(data_dir) / f"heap_{ts}.bin"
                 try:

--- a/poetry.lock
+++ b/poetry.lock
@@ -142,7 +142,7 @@ version = "1.17.1"
 description = "A database migration tool for SQLAlchemy."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "alembic-1.17.1-py3-none-any.whl", hash = "sha256:cbc2386e60f89608bb63f30d2d6cc66c7aaed1fe105bd862828600e5ad167023"},
     {file = "alembic-1.17.1.tar.gz", hash = "sha256:8a289f6778262df31571d29cca4c7fbacd2f0f582ea0816f4c399b6da7528486"},
@@ -1178,7 +1178,7 @@ version = "3.2.4"
 description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
 files = [
     {file = "greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c"},
@@ -1507,7 +1507,7 @@ version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -1665,7 +1665,7 @@ version = "2.1.0"
 description = "Links recognition library with FULL unicode support."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e"},
     {file = "linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b"},
@@ -1720,7 +1720,7 @@ version = "1.3.10"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59"},
     {file = "mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28"},
@@ -1740,7 +1740,7 @@ version = "4.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147"},
     {file = "markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"},
@@ -1836,7 +1836,7 @@ version = "0.5.0"
 description = "Collection of plugins for markdown-it-py"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f"},
     {file = "mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6"},
@@ -1856,7 +1856,7 @@ version = "0.1.2"
 description = "Markdown URL utilities"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
@@ -1868,7 +1868,7 @@ version = "1.19.2"
 description = "A memory profiler for Python applications"
 optional = false
 python-versions = ">=3.7.0"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "memray-1.19.2-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:50d7130bb0c8609176b3b691c8b67fc92805180166e087549a59e7881ae8cf36"},
     {file = "memray-1.19.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3643d601c4c1c413a62fb296598ed05dce1e1c3a58ea5c8659ae98ad36ce3a7a"},
@@ -2305,7 +2305,7 @@ version = "4.9.4"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868"},
     {file = "platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934"},
@@ -2703,7 +2703,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -3106,7 +3106,7 @@ version = "14.3.3"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.8.0"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d"},
     {file = "rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b"},
@@ -3342,7 +3342,7 @@ version = "2.0.43"
 description = "Database Abstraction Library"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "SQLAlchemy-2.0.43-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:21ba7a08a4253c5825d1db389d4299f64a100ef9800e4624c8bf70d8f136e6ed"},
     {file = "SQLAlchemy-2.0.43-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:11b9503fa6f8721bef9b8567730f664c5a5153d25e247aadc69247c4bc605227"},
@@ -3549,7 +3549,7 @@ version = "8.2.3"
 description = "Modern Text User Interface framework"
 optional = false
 python-versions = "<4.0,>=3.9"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "textual-8.2.3-py3-none-any.whl", hash = "sha256:5008ac581bebf1f6fa0520404261844a231e5715fdbddd10ca73916a3af48ca2"},
     {file = "textual-8.2.3.tar.gz", hash = "sha256:beea7b86b03b03558a2224f0cc35252e60ef8b0c4353b117b2f40972902d976a"},
@@ -3740,7 +3740,7 @@ version = "2.0.0"
 description = "Micro subset of unicode data files for linkify-it-py projects."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c"},
     {file = "uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811"},
@@ -4094,4 +4094,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "8111a9c1c8cd92a1f4b85f2318a782f33bf7f5659b7010a23b501e74831efa91"
+content-hash = "6d01480af8e8c23ac7a1d8706a24cd93748faa03199c067fff2158b44df108e5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,15 +44,15 @@ pyjwt = "^2.9"
 sqlalchemy = "^2.0"
 pgvector = "^0.4.1"
 psycopg2-binary = "^2.9"
-memray = "^1.19.2"
 croniter = "^6.2.2"
 bcrypt = "^5.0.0"
 weasyprint = "^66.0"
 grpcio = "^1.76.0"
+alembic = "^1.17.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.0"
-alembic = "^1.17.1"
+memray = "^1.19.2"
 testcontainers = {extras = ["postgres"], version = "^4.14.2"}
 ruff = "^0.15.9"
 pytest-cov = "^7.1.0"

--- a/rentmate/app.py
+++ b/rentmate/app.py
@@ -38,7 +38,7 @@ from memory_watchdog import set_memory_backstop, start_memory_monitor
 
 _PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 _DIST = _PACKAGE_ROOT / "www" / "rentmate-ui" / "dist"
-_DEFAULT_SCHEMA_MIGRATE_COMMAND = ["poetry", "run", "alembic", "upgrade", "head"]
+_DEFAULT_SCHEMA_MIGRATE_COMMAND = ["python", "-m", "alembic", "upgrade", "head"]
 _SCHEMA_MIGRATE_COMMANDS = [_DEFAULT_SCHEMA_MIGRATE_COMMAND]
 _SCHEMA_MIGRATE_CWD = _PACKAGE_ROOT
 _DEV_BOOTSTRAP_EMAIL = "test@test.com"


### PR DESCRIPTION
## Summary
- Convert backend Dockerfiles to multi-stage builds so build tools, Poetry, caches, and dev/test deps stay out of runtime images.
- Move Alembic into runtime dependencies and run migrations with `python -m alembic` so runtime no longer needs Poetry.
- Make memray optional at runtime and keep it as a dev dependency.
- Fix runtime copy set to include `rentmate/` and `memory_watchdog.py`.

## Size
- `rentmate-api-slim:test`: 426MB
- `rentmate-root-slim:test`: 426MB
- Previous `rentmate-dev-api:latest`: 1.14GB

## Verification
- `docker build -t rentmate-api-slim:test -f infra/backend.Dockerfile .`
- `docker build -t rentmate-root-slim:test -f Dockerfile .`
- Runtime import smoke passed; Poetry and memray absent from final image.
- `poetry run ruff check memory_watchdog.py`
- `poetry run pytest tests/test_startup.py tests/test_dev_compose_smoke.py -q` -> 16 passed
- `poetry run pytest tests/` -> 136 passed, 4 skipped, 1 failed due to existing GraphQL codegen CLI issue: `Unknown argument: config`

## Known Existing Issues
- Repo-wide `poetry run ruff check .` and `scripts/lint_kwargs.py` fail on unrelated existing violations across the repo.