### PR TITLE
Fix suggestion-status enum casing in autoreply hash query

### DIFF
--- a/handlers/chat.py
+++ b/handlers/chat.py
@@ -13,7 +13,7 @@ from typing import Dict, Optional
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from sqlalchemy import text
+from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -661,10 +661,18 @@ def _compute_autoreply_hash(task) -> str:
                 ), {"cid": conv_id}).scalar()
                 if ts:
                     parts.append(f"{conv_id}:{ts}")
-        # Pending suggestion count
-        count = db.execute(text(
-            "SELECT COUNT(*) FROM suggestions WHERE task_id = :tid AND status = 'pending'"
-        ), {"tid": task.id}).scalar()
+        # Pending suggestion count. Use the ORM so SQLAlchemy serializes
+        # SuggestionStatus.PENDING with the same casing as the DB enum
+        # (uppercase 'PENDING'); the previous raw SQL hard-coded the
+        # lowercase Python value and crashed on the real Postgres enum.
+        from db.enums import SuggestionStatus
+        from db.models import Suggestion
+        count = db.execute(
+            select(func.count()).select_from(Suggestion).where(
+                Suggestion.task_id == task.id,
+                Suggestion.status == SuggestionStatus.PENDING,
+            )
+        ).scalar()
         parts.append(f"suggestions:{count}")
         return hashlib.md5("|".join(parts).encode()).hexdigest()
     finally:


### PR DESCRIPTION
## Summary

`handlers/chat.py:_compute_autoreply_hash` had a hardcoded raw SQL `WHERE status = 'pending'` against the `suggestions` table. The Postgres `suggestion_status_enum` was created with **uppercase** labels (`PENDING/ACCEPTED/DISMISSED/EXPIRED`) per the baseline migration, and SQLAlchemy stores `SuggestionStatus` values in uppercase everywhere else via the default member-name serialization. The lowercase literal in that single raw-SQL site crashed Postgres with:

```
invalid input value for enum suggestion_status_enum: "pending"
LINE 1: ...*) FROM suggestions WHERE task_id = 4 AND status = 'pending'
```

Surfaced by the reply scanner whenever a task hit autoreply.

The fix rewrites the count through the SQLAlchemy ORM (`select(func.count()).select_from(Suggestion).where(Suggestion.status == SuggestionStatus.PENDING)`) so the enum is serialized the same way the rest of the codebase does — no DB migration needed.

Quick grep confirms this was the only raw-SQL enum literal of its kind.

## Test plan

- [x] `poetry run pytest handlers/tests/ -q -k "chat or autoreply"` — 6 pass; 3 unrelated failures are pre-existing env-driven (missing LLM_API_KEY in test env, unrelated to this query change).
- [x] Smoke test against live dev DB: `_compute_autoreply_hash(task)` returns a hash without raising the enum error.
- [ ] Manual: in the dev container, hitting the autoreply path that previously crashed (e.g. an inbound tenant reply on a task) should no longer log `invalid input value for enum suggestion_status_enum: "pending"`.

## Intentionally not done

- **Migrating the DB enum to lowercase labels** — the rest of the codebase has been writing/reading uppercase via SQLAlchemy's default member-name serialization for the lifetime of the schema. A rename migration is out of scope for this hotfix.