### PR TITLE
Ship demo/ module in rentmate package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ packages = [
   { include = "handlers" },
   { include = "backends" },
   { include = "llm" },
+  { include = "demo" },
 ]
 include = [
   { path = "pyproject.toml", format = ["sdist", "wheel"] },


### PR DESCRIPTION
## Summary

\`rentmate/app.py\` imports \`demo.seed\` (and, when \`RENTMATE_DEMO_SIMULATOR=1\`, \`demo.simulator\`) during dev startup. Until now \`demo\` lived only in the source tree — never in the \`packages\` list — so any consumer that installs rentmate as a wheel (rentmate-hosted, the install-smoke job) would log:

\`\`\`
Dev seed failed: No module named 'demo'
\`\`\`

at startup and the dev DB stayed empty. The hosted side hit this on the next rentmate bump (\`tests/test_startup.py::test_dev_bootstrap_account_has_expected_credentials_and_seed_data\`).

Adding \`{ include = "demo" }\` to \`packages\` makes the dev seed + simulator available wherever rentmate is installed.

No runtime imports outside dev mode; production code paths are unchanged.

## Test plan
- [x] \`poetry build\` (wheel includes \`demo/\`).
- [ ] Verify rentmate-hosted CI is green after this lands and bumps the rentmate pin.