### PR TITLE
Persist inferred task property and unit context

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -29,7 +29,7 @@ from llm.model_config import resolve_model_config
 from llm.registry import agent_registry
 from llm.rentmate_policy_provider import RentmatePolicyProvider
 from llm.runs import accumulate_run_totals, derive_run_metadata, start_run
-from llm.tools import current_user_message
+from llm.tools import current_request_context, current_user_message
 from llm.tracing import log_trace, make_trace_envelope
 
 AGENT_URL = os.getenv("RENTMATE_AGENT_URL")  # e.g. https://agent.rentmate.com
@@ -94,8 +94,8 @@ def _load_onboarding_prompt(*, session_key: str) -> str:
     if not str(session_key).startswith("chat:"):
         return ""
     try:
-        from db.session import SessionLocal
         from db.models import Property
+        from db.session import SessionLocal
         from gql.services.settings_service import get_onboarding_state
 
         db = SessionLocal()
@@ -550,6 +550,7 @@ async def chat_with_agent(
     if conversation_history and conversation_history[-1]["role"] == "user":
         user_message = conversation_history.pop()["content"]
     user_message_token = current_user_message.set(user_message)
+    request_context_token = current_request_context.set(trace_context)
 
     # Extract system message and conversation history. Pass user_message
     # into the bundle builder so persistent-memory retrieval is biased
@@ -575,9 +576,6 @@ async def chat_with_agent(
     def _tool_progress(event_type: str, tool_name: str, preview: str | None, args: dict | None, **kwargs):
         label = _TOOL_LABELS.get(tool_name, tool_name)
         trace_detail = current_trace_context.get() or trace_context or {}
-        trace_conversation_id = (
-            str(trace_detail.get("conversation_id") or "") if isinstance(trace_detail, dict) else ""
-        ) or _trace_conversation_id
         if event_type == "tool.started":
             hint = ""
             if args:
@@ -667,9 +665,6 @@ async def chat_with_agent(
         try:
             label = _TOOL_LABELS.get(function_name, function_name)
             trace_detail = current_trace_context.get() or trace_context or {}
-            trace_conversation_id = (
-                str(trace_detail.get("conversation_id") or "") if isinstance(trace_detail, dict) else ""
-            ) or _trace_conversation_id
 
             result_text = function_result if isinstance(function_result, str) else str(function_result or "")
             is_error = False
@@ -822,6 +817,7 @@ async def chat_with_agent(
         result = await _run_with_progress()
     finally:
         current_user_message.reset(user_message_token)
+        current_request_context.reset(request_context_token)
 
     if isinstance(result, dict):
         print(f"[agent] api_calls={result.get('api_calls', '?')} "
@@ -946,13 +942,14 @@ async def _local_fallback(
     trace_context: dict[str, Any] | None = None,
 ) -> AgentResponse:
     """Run the agent locally (dev mode)."""
-    from llm.tools import current_user_message, pending_suggestion_messages
+    from llm.tools import current_request_context, current_user_message, pending_suggestion_messages
 
     token = pending_suggestion_messages.set([])
     failed_tools_token = current_failed_tools.set([])
     completed_tools_token = current_completed_tools.set([])
     latest_user = next((m.get("content", "") for m in reversed(messages) if m.get("role") == "user"), "")
     user_token = current_user_message.set(latest_user)
+    request_context_token = current_request_context.set(trace_context)
     trace_token = current_trace_context.set(trace_context)
     fallback_token = None
     try:
@@ -1123,6 +1120,7 @@ async def _local_fallback(
         if fallback_token is not None:
             reset_fallback_request_context(fallback_token)
         current_user_message.reset(user_token)
+        current_request_context.reset(request_context_token)
         current_trace_context.reset(trace_token)
         current_failed_tools.reset(failed_tools_token)
         current_completed_tools.reset(completed_tools_token)

--- a/llm/tests/test_tool_public_ids.py
+++ b/llm/tests/test_tool_public_ids.py
@@ -39,6 +39,7 @@ from llm.tools import (
     SaveMemoryTool,
     UpdateTaskProgressTool,
     active_conversation_id,
+    current_request_context,
     current_user_message,
     pending_suggestion_messages,
 )
@@ -817,6 +818,62 @@ def test_propose_task_tool_uses_external_vendor_id_in_payload(db):
     suggestion = db.query(Suggestion).filter_by(id=payload["proposal_id"]).one()
     assert suggestion.action_payload["vendor_id"] == vendor.external_id
     assert suggestion.action_payload["action"] == "send_and_create_task"
+
+
+def test_propose_task_infers_property_and_unit_from_retrieval_context(db):
+    prop = _seed_property(db, name="The Meadows", address_line1="1842 Meadow Lane")
+    unit = Unit(org_id=1, creator_id=1, property_id=prop.id, label="1B")
+    vendor = User(
+        org_id=1,
+        creator_id=1,
+        user_type="vendor",
+        first_name="Sarah",
+        last_name="Chen",
+        role_label="Landscaper",
+        phone="+15550005555",
+        active=True,
+    )
+    db.add_all([unit, vendor])
+    db.flush()
+
+    context_token = current_request_context.set({
+        "retrieval": {
+            "items": [
+                {
+                    "source_type": "lease",
+                    "metadata": {
+                        "property_id": prop.id,
+                        "unit_id": unit.id,
+                    },
+                },
+            ],
+        },
+    })
+    try:
+        with patch("db.session.SessionLocal.session_factory", return_value=db), \
+             patch.object(db, "close", lambda: None):
+            payload = json.loads(_run_tool(
+                ProposeTaskTool(),
+                title="Schedule gutter cleaning for Priya Patel's unit",
+                category="maintenance",
+                vendor_id=vendor.external_id,
+                goal="Schedule gutter cleaning at The Meadows Unit 1B and confirm access with Priya.",
+                steps=[
+                    {"key": "confirm_vendor", "label": "Confirm vendor availability", "status": "active"},
+                    {"key": "coordinate_access", "label": "Coordinate tenant access", "status": "pending"},
+                    {"key": "complete_cleaning", "label": "Complete gutter cleaning", "status": "pending"},
+                ],
+            ))
+    finally:
+        current_request_context.reset(context_token)
+
+    assert payload["status"] == "pending_approval"
+    suggestion = db.query(Suggestion).filter_by(id=payload["proposal_id"]).one()
+    convo = db.query(Conversation).filter_by(id=suggestion.ai_conversation_id).one()
+    assert suggestion.property_id == prop.id
+    assert suggestion.unit_id == unit.id
+    assert convo.property_id == prop.id
+    assert convo.unit_id == unit.id
 
 
 def test_propose_task_tool_rejects_unknown_vendor_id(db):

--- a/llm/tools/__init__.py
+++ b/llm/tools/__init__.py
@@ -14,6 +14,7 @@ from llm.tools._common import (
     ToolCategory,
     ToolMode,
     active_conversation_id,
+    current_request_context,
     current_user_message,
     pending_suggestion_messages,
     simulation_suggestions,
@@ -33,7 +34,6 @@ from llm.tools.memory import EditMemoryTool, RecallMemoryTool, SaveMemoryTool
 from llm.tools.messaging import MessageExternalPersonTool
 from llm.tools.onboarding import UpdateOnboardingTool
 from llm.tools.task_review import AskManagerTool, RecordTaskReviewTool
-from llm.tools.time_tools import HasHappenedTool
 from llm.tools.tasks import (
     CloseTaskTool,
     CreateRoutineTool,
@@ -42,6 +42,7 @@ from llm.tools.tasks import (
     ProposeTaskTool,
     UpdateTaskProgressTool,
 )
+from llm.tools.time_tools import HasHappenedTool
 from llm.tools.vendors import CreateVendorTool, LookupVendorsTool
 
 __all__ = [
@@ -49,6 +50,7 @@ __all__ = [
     "ToolCategory",
     "ToolMode",
     "active_conversation_id",
+    "current_request_context",
     "current_user_message",
     "pending_suggestion_messages",
     "simulation_suggestions",

--- a/llm/tools/_common.py
+++ b/llm/tools/_common.py
@@ -12,9 +12,8 @@ from contextlib import contextmanager
 from enum import Enum
 from typing import Any
 
-from backends.local_auth import resolve_account_id, resolve_org_id
-from db.id_utils import normalize_optional_id
 from db.enums import AgentSource, SuggestionOption, Urgency
+from db.id_utils import normalize_optional_id
 from db.models import MessageType
 
 logger = logging.getLogger("rentmate.llm.tools")
@@ -140,6 +139,10 @@ current_user_message: contextvars.ContextVar[str | None] = contextvars.ContextVa
     "current_user_message", default=None,
 )
 
+current_request_context: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
+    "current_request_context", default=None,
+)
+
 # When set, tools classified as read-write short-circuit inside the
 # dispatcher: the inputs are appended here and ``execute`` is skipped.
 # Read-only tools still run normally. See ``ToolMode`` + ``is_simulating``.
@@ -245,8 +248,7 @@ def _load_vendor_by_public_id(db: Any, vendor_id: str):
 
 
 def _load_tenant_by_public_id(db: Any, tenant_id: str):
-    from db.models import Tenant
-    from db.models import User
+    from db.models import Tenant, User
 
     tenant_id = normalize_optional_id(tenant_id)
     if tenant_id is None:
@@ -306,7 +308,7 @@ def _load_entity_by_public_id(db: Any, entity_type: str, entity_id: str):
 
 
 def _sanitize_tenant_outbound_draft(db: Any, *, task_id: str, draft_message: str) -> str:
-    from db.models import Conversation, ParticipantType, Task, User
+    from db.models import ParticipantType, Task, User
 
     draft = str(draft_message or "")
     if not draft:

--- a/llm/tools/tasks.py
+++ b/llm/tools/tasks.py
@@ -18,6 +18,7 @@ from llm.tools._common import (
     _recent_user_messages,
     _resolve_task_id_from_active_conversation,
     _sanitize_tenant_outbound_draft,
+    current_request_context,
     current_user_message,
 )
 
@@ -373,6 +374,69 @@ def _current_task_notice_service_reported(task_id: str) -> bool:
         db.close()
 
 
+def _trace_retrieval_items(context: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(context, dict):
+        return []
+    candidates = [
+        context.get("retrieval"),
+        (context.get("context") or {}).get("retrieval") if isinstance(context.get("context"), dict) else None,
+    ]
+    items: list[dict[str, Any]] = []
+    for candidate in candidates:
+        if isinstance(candidate, dict) and isinstance(candidate.get("items"), list):
+            items.extend(item for item in candidate["items"] if isinstance(item, dict))
+    return items
+
+
+def _first_context_id(context: dict[str, Any] | None, key: str) -> str | None:
+    if not isinstance(context, dict):
+        return None
+    for candidate in [
+        context,
+        context.get("request"),
+        context.get("retrieval"),
+        (context.get("retrieval") or {}).get("request") if isinstance(context.get("retrieval"), dict) else None,
+        (context.get("context") or {}).get("retrieval", {}).get("request")
+        if isinstance(context.get("context"), dict)
+        and isinstance((context.get("context") or {}).get("retrieval"), dict)
+        else None,
+    ]:
+        if isinstance(candidate, dict):
+            value = (candidate.get(key) or "").strip() if isinstance(candidate.get(key), str) else candidate.get(key)
+            if value:
+                return str(value)
+    return None
+
+
+def _infer_task_location_from_request_context() -> tuple[str | None, str | None]:
+    """Infer property/unit from server-side retrieval metadata when the LLM omits IDs."""
+    context = current_request_context.get()
+    property_id = _first_context_id(context, "property_id")
+    unit_id = _first_context_id(context, "unit_id")
+    if property_id or unit_id:
+        return property_id, unit_id
+
+    property_ids: list[str] = []
+    unit_ids: list[str] = []
+    for item in _trace_retrieval_items(context):
+        if item.get("source_type") not in {"lease", "property", "unit", "tenant"}:
+            continue
+        metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        item_property_id = metadata.get("property_id")
+        item_unit_id = metadata.get("unit_id")
+        if item_property_id:
+            property_ids.append(str(item_property_id))
+        if item_unit_id:
+            unit_ids.append(str(item_unit_id))
+
+    unique_property_ids = list(dict.fromkeys(property_ids))
+    unique_unit_ids = list(dict.fromkeys(unit_ids))
+    return (
+        unique_property_ids[0] if len(unique_property_ids) == 1 else None,
+        unique_unit_ids[0] if len(unique_unit_ids) == 1 else None,
+    )
+
+
 def _same_task_handoff_block_message() -> str:
     return (
         "Do not create a new suggestion or task for this. Stay in the current task, "
@@ -602,7 +666,8 @@ class ProposeTaskTool(Tool):
                 "description": {"type": "string", "description": "Detailed context for the task"},
                 "vendor_id": {"type": "string", "description": "External UUID of the vendor to assign (use lookup_vendors to find this)"},
                 "draft_message": {"type": "string", "description": "Draft message to send to the vendor on approval"},
-                "property_id": {"type": "string", "description": "Property ID (if applicable)"},
+                "property_id": {"type": "string", "description": "Property ID (if applicable). Use the resolved property ID from context or lookup_properties."},
+                "unit_id": {"type": "string", "description": "Unit ID (if applicable). Use the resolved unit ID from context or lookup_properties."},
                 "task_id": {"type": "string", "description": "Originating task ID (if applicable)"},
                 "risk_score": {
                     "type": "integer",
@@ -660,7 +725,7 @@ class ProposeTaskTool(Tool):
                 ),
             })
 
-        from db.models import Property
+        from db.models import Property, Unit
         from db.session import SessionLocal
         db = SessionLocal.session_factory()
         try:
@@ -686,6 +751,10 @@ class ProposeTaskTool(Tool):
             # plausible-sounding property_ids ("the bothell house") would
             # otherwise create suggestions for properties that don't exist.
             property_id = (kwargs.get("property_id") or "").strip() or None
+            unit_id = (kwargs.get("unit_id") or "").strip() or None
+            inferred_property_id, inferred_unit_id = _infer_task_location_from_request_context()
+            property_id = property_id or inferred_property_id
+            unit_id = unit_id or inferred_unit_id
             if property_id:
                 prop = db.query(Property).filter(
                     Property.id == property_id,
@@ -701,6 +770,29 @@ class ProposeTaskTool(Tool):
                             "property_id — never invent one."
                         ),
                     })
+            if unit_id:
+                unit = db.query(Unit).filter(
+                    Unit.id == unit_id,
+                    Unit.org_id == resolve_org_id(),
+                ).first()
+                if not unit:
+                    return json.dumps({
+                        "status": "error",
+                        "message": (
+                            f"Unit {unit_id} not found. Call `lookup_properties` "
+                            "and use a returned unit_id — never invent one."
+                        ),
+                    })
+                if property_id and unit.property_id and str(unit.property_id) != str(property_id):
+                    return json.dumps({
+                        "status": "error",
+                        "message": (
+                            f"Unit {unit_id} belongs to property {unit.property_id}, "
+                            f"not property {property_id}. Use matching property_id/unit_id values."
+                        ),
+                    })
+                if not property_id and unit.property_id:
+                    property_id = str(unit.property_id)
         finally:
             db.close()
 
@@ -759,7 +851,8 @@ class ProposeTaskTool(Tool):
             action_payload=action_payload,
             options=options,
             task_id=kwargs.get("task_id") or task_id or None,
-            property_id=kwargs.get("property_id"),
+            property_id=property_id,
+            unit_id=unit_id,
             risk_score=risk,
             suggestion_type=kwargs["category"],
         )


### PR DESCRIPTION
## Summary
- carry agent request/retrieval context into tool execution
- infer property_id and unit_id for propose_task from resolved retrieval metadata when omitted by the model
- validate explicit or inferred property/unit IDs before creating the task proposal
- persist both IDs on the suggestion so approval creates a properly linked task

## Verification
- /home/aj/.cache/pypoetry/virtualenvs/rentmate-UFMNINIZ-py3.12/bin/ruff check llm/client.py llm/tools/__init__.py llm/tools/_common.py llm/tools/tasks.py llm/tests/test_tool_public_ids.py
- /home/aj/.cache/pypoetry/virtualenvs/rentmate-UFMNINIZ-py3.12/bin/python -m pytest llm/tests/test_tool_public_ids.py -k "propose_task" --tb=short