### PR TITLE
Backfill agent_memory.agent_id on legacy schemas

### DIFF
--- a/db/migrations/versions/c2f3e4d5a6b8_backfill_agent_memory_agent_id.py
+++ b/db/migrations/versions/c2f3e4d5a6b8_backfill_agent_memory_agent_id.py
@@ -1,0 +1,65 @@
+"""Backfill agent_memory.agent_id on legacy schemas
+
+The ``agent_memory.agent_id`` column has been declared on the model
+since the baseline schema, but production hosted databases that were
+provisioned before the alembic baseline existed got stamped at
+``13fb4c59240f`` (head at the time) without the baseline migration
+ever running. The column has therefore been silently missing on those
+DBs ever since, and the most recent rentmate bump tripped on it
+(``UndefinedColumn: column agent_memory.agent_id does not exist``)
+which then aborted every downstream query in the same transaction.
+
+This migration adds the column ``IF NOT EXISTS`` and backfills any
+existing rows from ``creator_id`` (the lambda default the model uses
+for new inserts), then locks down ``NOT NULL`` + ``DEFAULT ''``.
+Idempotent — a clean baseline install that already created the column
+makes this a no-op.
+
+Revision ID: c2f3e4d5a6b8
+Revises: b4d8e9f0a1c2
+Create Date: 2026-04-26
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "c2f3e4d5a6b8"
+down_revision: Union[str, Sequence[str], None] = "b4d8e9f0a1c2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "agent_memory" not in inspector.get_table_names():
+        # Fresh install where the table doesn't exist yet — let the
+        # baseline migration handle it.
+        return
+    cols = {c["name"] for c in inspector.get_columns("agent_memory")}
+    if "agent_id" in cols:
+        return
+
+    op.add_column(
+        "agent_memory",
+        sa.Column("agent_id", sa.String(length=255), nullable=True),
+    )
+    op.execute(
+        "UPDATE agent_memory SET agent_id = creator_id::text "
+        "WHERE agent_id IS NULL"
+    )
+    op.alter_column("agent_memory", "agent_id", nullable=False, server_default="")
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "agent_memory" not in inspector.get_table_names():
+        return
+    cols = {c["name"] for c in inspector.get_columns("agent_memory")}
+    if "agent_id" not in cols:
+        return
+    op.drop_column("agent_memory", "agent_id")


### PR DESCRIPTION
## Summary

The \`agent_memory.agent_id\` column has been declared on the model since the baseline schema, but production hosted databases that were provisioned **before** the alembic baseline existed got stamped at \`13fb4c59240f\` (head at the time) without the baseline migration ever running. The column has been silently missing on those DBs since.

\`\`\`
psycopg2.errors.UndefinedColumn: column agent_memory.agent_id does not exist
\`\`\`
... which then aborted the whole transaction and crashed routine simulation with \`current transaction is aborted, commands ignored until end of transaction block\` on every later query in the same session.

## Migration shape

- Inspector-gated. If \`agent_memory\` doesn't exist (fresh install) or \`agent_id\` already exists (clean baseline), it's a no-op.
- Otherwise: \`ADD COLUMN agent_id VARCHAR(255) NULL\`, \`UPDATE … SET agent_id = creator_id::text\`, then lock down \`NOT NULL\` + \`DEFAULT ''\`.
- Re-running \`alembic upgrade head\` is also a no-op.

## Test plan
- [x] Testcontainer Postgres seeded with a legacy-shape \`agent_memory\` (no \`agent_id\`) + stamp at the previous head → migration adds the column, backfills, sets \`NOT NULL\`, second \`upgrade head\` is no-op.
- [x] \`poetry run pytest tests/test_startup.py -q\` (15 tests, exercises the full chain on a fresh DB) passes.
- [ ] CI green
- [x] Manual: routine simulation in prod no longer 500s with \`agent_memory.agent_id does not exist\` after the live ALTER.

## Why this is a rentmate-side migration (not hosted-side)

\`agent_memory\` is a rentmate-owned table; its model and original baseline live in this repo. Putting the fix in rentmate's chain means every consumer (hosted, install-smoke, anyone running rentmate locally on a legacy DB) gets it automatically when they pull a newer rentmate.

## Related

- Root cause analysis: hosted's \`_maybe_stamp_head\` shortcut bypassed the baseline migration on long-lived prod DBs. Worth a follow-up to either retire that shortcut or have it run a more thorough reconciliation.