### PR TITLE
GraphQL: searchTenants + suggestReply for the chrome extension

### DIFF
--- a/gql/schema.py
+++ b/gql/schema.py
@@ -47,10 +47,13 @@ from .types import (
     SpawnTaskInput,
     SuggestionStatusEnum,
     SuggestionType,
+    SuggestReplyInput,
+    SuggestReplyResult,
     TaskCategoryEnum,
     TaskSourceEnum,
     TaskStatusEnum,
     TaskType,
+    TenantSearchResult,
     TenantType,
     UpdatePropertyInput,
     UpdateTaskInput,
@@ -249,6 +252,12 @@ class Query:
     ) -> typing.List[ConversationSummaryType]:
         _current_user(info)
         return [ConversationSummaryType.from_sql(c) for c in fetch_conversations(_session(info), conversation_type=conversation_type, limit=limit, offset=offset)]
+
+    @strawberry.field(description="Fuzzy-match tenants by name / email / phone. Top 3 ranked.")
+    def search_tenants(self, info: Info, *, query: str) -> typing.List[TenantSearchResult]:
+        from gql.services.extension_service import rank_tenants
+        _current_user(info)
+        return [TenantSearchResult.from_dict(r) for r in rank_tenants(_session(info), query)]
 
 
 # ---------------------------
@@ -802,6 +811,30 @@ class Mutation(AuthMutation):
         sess.commit()
         sess.refresh(task)
         return TaskType.from_sql(task)
+
+    @strawberry.mutation(description=(
+        "One-shot agent-drafted reply for a TenantCloud conversation viewed "
+        "in the chrome extension. Pure read on rentmate data — no DB writes."
+    ))
+    async def suggest_reply(self, info: Info, *, input: SuggestReplyInput) -> SuggestReplyResult:
+        from gql.services.extension_service import draft_reply
+        _current_user(info)
+        result = await draft_reply(
+            _session(info),
+            conversation_history=[
+                {"sender": turn.sender, "text": turn.text}
+                for turn in (input.conversation_history or [])
+            ],
+            header_title=input.header_title,
+            header_description=input.header_description,
+            tenant_id=input.tenant_id,
+            property_id=input.property_id,
+        )
+        matched = result.get("matched_tenant")
+        return SuggestReplyResult(
+            suggestion=result["suggestion"],
+            matched_tenant=TenantSearchResult.from_dict(matched) if matched else None,
+        )
 
 
 # ---------------------------

--- a/gql/services/extension_service.py
+++ b/gql/services/extension_service.py
@@ -1,0 +1,208 @@
+"""Helpers for the GraphQL fields the chrome extension calls.
+
+Two responsibilities:
+
+- ``rank_tenants`` — fuzzy-search the org's active tenants by name, email,
+  or phone. Used by the extension to map a TenantCloud sender name onto a
+  rentmate tenant id before drafting a reply.
+- ``draft_reply`` — one-shot LiteLLM completion that returns an SMS-style
+  reply for the conversation the PM is looking at in TenantCloud. No DB
+  writes, no agent loop, no tools. On any LLM error it falls back to a
+  canned acknowledgement so the extension never crashes.
+
+Both helpers run inside a request context that already has org/account
+ids resolved (subdomain middleware / JWT auth), so they don't take ids
+explicitly — they piggyback on ``fetch_tenants`` / ``resolve_org_id``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from db.queries import fetch_tenants
+
+logger = logging.getLogger("rentmate.gql.extension")
+
+
+_FALLBACK_REPLY = "I'll follow up on this shortly."
+
+_EXACT_MATCH_SCORE = 100
+_FULL_NAME_MATCH_SCORE = 50
+_PARTIAL_NAME_MATCH_SCORE = 25
+_MAX_RESULTS = 3
+
+
+def _score_tenant(tenant: Any, query: str) -> int:
+    """Return a 0-100 fuzzy-match score; 0 means no meaningful match."""
+    user = getattr(tenant, "user", None)
+    if user is None:
+        return 0
+
+    email = (user.email or "").strip().lower()
+    phone = (user.phone or "").strip().lower()
+    first = (user.first_name or "").strip().lower()
+    last = (user.last_name or "").strip().lower()
+    full = f"{first} {last}".strip()
+
+    if email and query == email:
+        return _EXACT_MATCH_SCORE
+    if phone and query == phone:
+        return _EXACT_MATCH_SCORE
+    if email and query in email:
+        return _FULL_NAME_MATCH_SCORE
+    if full and query in full:
+        return _FULL_NAME_MATCH_SCORE
+    if first and query in first:
+        return _PARTIAL_NAME_MATCH_SCORE
+    if last and query in last:
+        return _PARTIAL_NAME_MATCH_SCORE
+    return 0
+
+
+def _result_payload(tenant: Any, score: int) -> dict[str, Any]:
+    """Shape a tenant + score into the dict the GraphQL type uses."""
+    user = tenant.user
+    name = " ".join(filter(None, [user.first_name, user.last_name])).strip() or "Tenant"
+    leases = list(getattr(tenant, "leases", []) or [])
+    lease = leases[0] if leases else None
+    property_id = None
+    unit_label = None
+    if lease is not None:
+        prop = getattr(lease, "property", None)
+        if prop is not None:
+            property_id = str(prop.id)
+        unit = getattr(lease, "unit", None)
+        if unit is not None:
+            unit_label = unit.label
+    return {
+        "tenant_id": str(tenant.external_id),
+        "name": name,
+        "email": user.email or None,
+        "phone": user.phone or None,
+        "property_id": property_id,
+        "unit_label": unit_label,
+        "score": score,
+    }
+
+
+def rank_tenants(db: Any, query: str) -> list[dict[str, Any]]:
+    """Return the top 3 tenants matching ``query``, ordered by score desc
+    then name asc. Returns ``[]`` if nothing meaningfully matches."""
+    needle = (query or "").strip().lower()
+    if not needle:
+        return []
+    scored: list[tuple[int, str, Any]] = []
+    for tenant in fetch_tenants(db):
+        score = _score_tenant(tenant, needle)
+        if score <= 0:
+            continue
+        sort_name = " ".join(filter(None, [
+            (tenant.user.first_name or "").lower(),
+            (tenant.user.last_name or "").lower(),
+        ])).strip()
+        scored.append((score, sort_name, tenant))
+    scored.sort(key=lambda row: (-row[0], row[1]))
+    return [_result_payload(t, score) for score, _name, t in scored[:_MAX_RESULTS]]
+
+
+def _resolve_tenant_for_reply(db: Any, tenant_id: str | None) -> dict[str, Any] | None:
+    """Resolve a TenantSearchResult-shaped payload for a known external
+    tenant id. Used so the suggestReply mutation can echo back the matched
+    tenant for the extension UI."""
+    if not tenant_id:
+        return None
+    for tenant in fetch_tenants(db):
+        if str(tenant.external_id) == str(tenant_id):
+            return _result_payload(tenant, _EXACT_MATCH_SCORE)
+    return None
+
+
+def _build_system_prompt(*, tenant_payload: dict[str, Any] | None, header_title: str | None, header_description: str | None) -> str:
+    intro = (
+        "You are RentMate drafting a reply on behalf of the property "
+        "manager. The PM is composing a response to a tenant inside "
+        "TenantCloud. Draft a single SMS-style reply, 1-3 sentences, "
+        "warm and professional. Do not invent facts or commit to dates. "
+        "Do not mention RentMate or that you are an AI."
+    )
+    parts: list[str] = [intro]
+    if tenant_payload:
+        unit = f" ({tenant_payload['unit_label']})" if tenant_payload.get("unit_label") else ""
+        parts.append(
+            f"You are replying to {tenant_payload['name']}{unit}, "
+            "an active tenant. Address them by first name."
+        )
+    if header_title:
+        parts.append(f"Maintenance request title: {header_title}")
+    if header_description:
+        parts.append(f"Maintenance request details: {header_description}")
+    return "\n".join(parts)
+
+
+def _build_user_message(history: list[dict[str, str]]) -> str:
+    if not history:
+        return "(No prior messages.) Open the conversation with a brief acknowledgement."
+    transcript = "\n".join(
+        f"{(turn.get('sender') or 'Tenant')}: {(turn.get('text') or '').strip()}"
+        for turn in history
+        if (turn.get('text') or '').strip()
+    )
+    return (
+        "Recent conversation between the property manager and the tenant "
+        "(most recent last):\n\n"
+        f"{transcript}\n\n"
+        "Draft the property manager's next reply. Output only the reply "
+        "text, no labels."
+    )
+
+
+async def draft_reply(
+    db: Any,
+    *,
+    conversation_history: list[dict[str, str]],
+    header_title: str | None,
+    header_description: str | None,
+    tenant_id: str | None,
+    property_id: str | None,
+) -> dict[str, Any]:
+    """Run a single LiteLLM completion and return the drafted reply +
+    matched-tenant echo. Falls back to a canned reply on any LLM error."""
+    import litellm
+
+    from llm.model_config import build_litellm_request_kwargs
+
+    matched_tenant = _resolve_tenant_for_reply(db, tenant_id)
+    system = _build_system_prompt(
+        tenant_payload=matched_tenant,
+        header_title=header_title,
+        header_description=header_description,
+    )
+    user_msg = _build_user_message(conversation_history or [])
+
+    model = os.getenv("LLM_MODEL", "openai/gpt-4o-mini")
+    kwargs = build_litellm_request_kwargs(
+        model=model,
+        api_base=os.getenv("LLM_BASE_URL") or None,
+        api_key=os.getenv("LLM_API_KEY"),
+        app_name="rentmate-chrome-extension",
+    )
+    try:
+        resp = await litellm.acompletion(
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user_msg},
+            ],
+            max_tokens=200,
+            temperature=0.4,
+            **kwargs,
+        )
+        suggestion = (resp.choices[0].message.content or "").strip()
+        if not suggestion:
+            raise ValueError("empty completion")
+        suggestion = suggestion[:500]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[extension] suggestReply LLM failed; using canned: %s", exc)
+        suggestion = _FALLBACK_REPLY
+
+    return {"suggestion": suggestion, "matched_tenant": matched_tenant}

--- a/gql/services/tests/test_extension_service.py
+++ b/gql/services/tests/test_extension_service.py
@@ -1,0 +1,212 @@
+"""Tests for ``gql/services/extension_service.py`` — the helpers behind
+the chrome-extension GraphQL surface (``searchTenants`` query and
+``suggestReply`` mutation)."""
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backends.local_auth import reset_request_context, set_request_context
+from db.models import Lease, Property, Tenant, Unit, User
+from gql.services.extension_service import (
+    _FALLBACK_REPLY,
+    draft_reply,
+    rank_tenants,
+)
+
+
+@contextmanager
+def _request_scope(*, account_id=1, org_id=1):
+    token = set_request_context(account_id=account_id, org_id=org_id)
+    try:
+        yield
+    finally:
+        reset_request_context(token)
+
+
+def _seed_tenant(db, *, first, last, email=None, phone=None, with_lease=False):
+    user = User(
+        org_id=1, creator_id=1, user_type="tenant",
+        first_name=first, last_name=last,
+        email=email, phone=phone,
+    )
+    db.add(user)
+    db.flush()
+    tenant = Tenant(org_id=1, creator_id=1, user_id=user.id)
+    db.add(tenant)
+    db.flush()
+    if with_lease:
+        prop = Property(
+            id=f"prop-{first.lower()}",
+            org_id=1, creator_id=1,
+            name="The Meadows", address_line1="1 Main St",
+            property_type="multi_family",
+        )
+        unit = Unit(
+            id=f"unit-{first.lower()}",
+            org_id=1, creator_id=1,
+            property_id=prop.id, label="1A",
+        )
+        db.add_all([prop, unit])
+        db.flush()
+        lease = Lease(
+            id=f"lease-{first.lower()}",
+            org_id=1, creator_id=1,
+            tenant_id=tenant.id, property_id=prop.id, unit_id=unit.id,
+            start_date=date(2024, 1, 1), end_date=date(2099, 1, 1),
+            rent_amount=1500.0,
+        )
+        db.add(lease)
+        db.flush()
+    return tenant
+
+
+# ─── rank_tenants ───────────────────────────────────────────────────────
+
+
+def test_rank_tenants_exact_email_beats_partial_name(db):
+    with _request_scope():
+        _seed_tenant(db, first="Marcus", last="Johnson", email="marcus@example.com")
+        _seed_tenant(db, first="Marcus", last="Williams", email="marcusw@example.com")
+
+        out = rank_tenants(db, "marcus@example.com")
+
+        # The first hit is the exact-email match (score 100). The second
+        # tenant scores lower because "marcus@example.com" is a substring
+        # of his email but not an exact match.
+        assert len(out) >= 1
+        assert out[0]["name"] == "Marcus Johnson"
+        assert out[0]["score"] == 100
+        if len(out) > 1:
+            assert out[1]["score"] < 100
+
+
+def test_rank_tenants_drops_zero_score_results(db):
+    with _request_scope():
+        _seed_tenant(db, first="Marcus", last="Johnson")
+        _seed_tenant(db, first="Priya", last="Patel")
+
+        assert rank_tenants(db, "xyzzy") == []
+
+
+def test_rank_tenants_caps_at_three(db):
+    with _request_scope():
+        for i in range(5):
+            _seed_tenant(db, first="Marcus", last=f"Last{i}")
+
+        out = rank_tenants(db, "marcus")
+
+        assert len(out) == 3
+        assert all("Marcus" in r["name"] for r in out)
+
+
+def test_rank_tenants_includes_property_and_unit_when_lease_exists(db):
+    with _request_scope():
+        _seed_tenant(db, first="Marcus", last="Johnson", with_lease=True)
+
+        out = rank_tenants(db, "marcus")
+
+        assert len(out) == 1
+        assert out[0]["unit_label"] == "1A"
+        assert out[0]["property_id"] == "prop-marcus"
+
+
+def test_rank_tenants_blank_query_returns_empty(db):
+    with _request_scope():
+        _seed_tenant(db, first="Marcus", last="Johnson")
+        assert rank_tenants(db, "   ") == []
+
+
+# ─── draft_reply ────────────────────────────────────────────────────────
+
+
+def _fake_completion(text: str):
+    fake = MagicMock()
+    fake.choices = [MagicMock(message=MagicMock(content=text))]
+    return fake
+
+
+def test_draft_reply_includes_tenant_name_in_system_prompt(db):
+    with _request_scope():
+        tenant = _seed_tenant(
+            db, first="Marcus", last="Johnson", email="marcus@example.com",
+            with_lease=True,
+        )
+        captured: dict = {}
+
+        async def fake_acompletion(messages, **_kwargs):
+            captured["system"] = messages[0]["content"]
+            captured["user"] = messages[1]["content"]
+            return _fake_completion("Hi Marcus — I'll get someone out to take a look.")
+
+        with patch("litellm.acompletion", side_effect=fake_acompletion):
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[
+                    {"sender": "Marcus", "text": "The dishwasher leaked again."},
+                ],
+                header_title="Dishwasher leak",
+                header_description=None,
+                tenant_id=str(tenant.external_id),
+                property_id=None,
+            ))
+
+    assert "Marcus Johnson" in captured["system"]
+    assert "Dishwasher leak" in captured["system"]
+    assert result["matched_tenant"]["tenant_id"] == str(tenant.external_id)
+    assert result["suggestion"].startswith("Hi Marcus")
+
+
+def test_draft_reply_falls_back_on_llm_error(db):
+    with _request_scope():
+        with patch("litellm.acompletion", new_callable=AsyncMock, side_effect=RuntimeError("network")):
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "Tenant", "text": "Hi?"}],
+                header_title=None,
+                header_description=None,
+                tenant_id=None,
+                property_id=None,
+            ))
+
+    assert result["suggestion"] == _FALLBACK_REPLY
+    assert result["matched_tenant"] is None
+
+
+def test_draft_reply_clamps_long_completion(db):
+    with _request_scope():
+        long_text = "x" * 1000
+
+        async def fake_acompletion(*_args, **_kwargs):
+            return _fake_completion(long_text)
+
+        with patch("litellm.acompletion", side_effect=fake_acompletion):
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "T", "text": "hi"}],
+                header_title=None, header_description=None,
+                tenant_id=None, property_id=None,
+            ))
+
+    assert len(result["suggestion"]) <= 500
+
+
+def test_draft_reply_unknown_tenant_id_returns_no_match(db):
+    with _request_scope():
+        async def fake_acompletion(*_args, **_kwargs):
+            return _fake_completion("OK.")
+
+        with patch("litellm.acompletion", side_effect=fake_acompletion):
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "T", "text": "hi"}],
+                header_title=None, header_description=None,
+                tenant_id="00000000-0000-0000-0000-000000000bad",
+                property_id=None,
+            ))
+
+    assert result["matched_tenant"] is None

--- a/gql/tests/test_extension_schema.py
+++ b/gql/tests/test_extension_schema.py
@@ -1,0 +1,213 @@
+"""Integration tests for the chrome-extension GraphQL surface.
+
+Exercises ``Query.searchTenants`` and ``Mutation.suggestReply`` end-to-end
+through the strawberry schema, including auth gating.
+"""
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backends.local_auth import reset_request_context, set_request_context
+from db.models import Lease, Property, Tenant, Unit, User
+from gql.schema import schema
+
+
+def _execute(*args, **kwargs):
+    return asyncio.run(schema.execute(*args, **kwargs))
+
+
+@contextmanager
+def _request_scope(*, account_id=1, org_id=1):
+    token = set_request_context(account_id=account_id, org_id=org_id)
+    try:
+        yield
+    finally:
+        reset_request_context(token)
+
+
+def _ctx(db, *, authed=True):
+    return {
+        "db_session": db,
+        "user": (
+            {"id": 1, "uid": "user-external-123", "email": "admin@example.com"}
+            if authed else None
+        ),
+    }
+
+
+def _seed_tenant(db, *, first, last, email=None, with_lease=False):
+    user = User(
+        org_id=1, creator_id=1, user_type="tenant",
+        first_name=first, last_name=last, email=email,
+    )
+    db.add(user)
+    db.flush()
+    tenant = Tenant(org_id=1, creator_id=1, user_id=user.id)
+    db.add(tenant)
+    db.flush()
+    if with_lease:
+        prop = Property(
+            id=f"prop-{first.lower()}",
+            org_id=1, creator_id=1,
+            name="The Meadows", address_line1="1 Main St",
+            property_type="multi_family",
+        )
+        unit = Unit(
+            id=f"unit-{first.lower()}",
+            org_id=1, creator_id=1,
+            property_id=prop.id, label="1A",
+        )
+        db.add_all([prop, unit])
+        db.flush()
+        lease = Lease(
+            id=f"lease-{first.lower()}",
+            org_id=1, creator_id=1,
+            tenant_id=tenant.id, property_id=prop.id, unit_id=unit.id,
+            start_date=date(2024, 1, 1), end_date=date(2099, 1, 1),
+            rent_amount=1500.0,
+        )
+        db.add(lease)
+        db.flush()
+    return tenant
+
+
+def test_search_tenants_requires_auth(db):
+    with _request_scope():
+        result = _execute(
+            """
+            query {
+              searchTenants(query: "marcus") {
+                tenantId
+                name
+                score
+              }
+            }
+            """,
+            context_value=_ctx(db, authed=False),
+        )
+    assert result.errors
+    assert "Not authenticated" in result.errors[0].message
+
+
+def test_search_tenants_returns_ranked_payload(db):
+    with _request_scope():
+        _seed_tenant(db, first="Marcus", last="Johnson", with_lease=True)
+        _seed_tenant(db, first="Priya", last="Patel")
+
+        result = _execute(
+            """
+            query {
+              searchTenants(query: "marcus") {
+                tenantId
+                name
+                score
+                unitLabel
+                propertyId
+              }
+            }
+            """,
+            context_value=_ctx(db),
+        )
+    assert result.errors is None, result.errors
+    rows = result.data["searchTenants"]
+    assert len(rows) == 1
+    assert rows[0]["name"] == "Marcus Johnson"
+    assert rows[0]["score"] >= 25
+    assert rows[0]["unitLabel"] == "1A"
+
+
+def test_suggest_reply_requires_auth(db):
+    with _request_scope():
+        result = _execute(
+            """
+            mutation {
+              suggestReply(input: {
+                conversationHistory: [{sender: "Tenant", text: "hi"}]
+              }) {
+                suggestion
+              }
+            }
+            """,
+            context_value=_ctx(db, authed=False),
+        )
+    assert result.errors
+    assert "Not authenticated" in result.errors[0].message
+
+
+def test_suggest_reply_returns_matched_tenant_in_payload(db):
+    with _request_scope():
+        tenant = _seed_tenant(
+            db, first="Marcus", last="Johnson", email="marcus@example.com",
+            with_lease=True,
+        )
+
+        async def fake_acompletion(*_args, **_kwargs):
+            fake = MagicMock()
+            fake.choices = [MagicMock(message=MagicMock(
+                content="Hi Marcus — got it, will follow up shortly.",
+            ))]
+            return fake
+
+        with patch("litellm.acompletion", side_effect=fake_acompletion):
+            result = _execute(
+                """
+                mutation Suggest($input: SuggestReplyInput!) {
+                  suggestReply(input: $input) {
+                    suggestion
+                    matchedTenant {
+                      tenantId
+                      name
+                      score
+                    }
+                  }
+                }
+                """,
+                variable_values={
+                    "input": {
+                        "conversationHistory": [
+                            {"sender": "Marcus", "text": "Dishwasher leaking again."},
+                        ],
+                        "headerTitle": "Dishwasher leak",
+                        "tenantId": str(tenant.external_id),
+                    },
+                },
+                context_value=_ctx(db),
+            )
+    assert result.errors is None, result.errors
+    payload = result.data["suggestReply"]
+    assert "Marcus" in payload["suggestion"]
+    assert payload["matchedTenant"]["tenantId"] == str(tenant.external_id)
+    assert payload["matchedTenant"]["name"] == "Marcus Johnson"
+    assert payload["matchedTenant"]["score"] == 100
+
+
+def test_suggest_reply_returns_canned_fallback_on_llm_error(db):
+    with _request_scope():
+        async def boom(*_args, **_kwargs):
+            raise RuntimeError("network down")
+
+        with patch("litellm.acompletion", side_effect=boom):
+            result = _execute(
+                """
+                mutation Suggest($input: SuggestReplyInput!) {
+                  suggestReply(input: $input) {
+                    suggestion
+                    matchedTenant { tenantId }
+                  }
+                }
+                """,
+                variable_values={
+                    "input": {
+                        "conversationHistory": [{"sender": "T", "text": "hi"}],
+                    },
+                },
+                context_value=_ctx(db),
+            )
+    assert result.errors is None, result.errors
+    assert result.data["suggestReply"]["matchedTenant"] is None
+    assert result.data["suggestReply"]["suggestion"] == "I'll follow up on this shortly."

--- a/gql/types.py
+++ b/gql/types.py
@@ -1169,3 +1169,59 @@ class ConversationSummaryType:
             task_id=task_id,
             task_title=task_title,
         )
+
+
+# ---------------------------------------------------------------------------
+# Chrome extension surface (TenantCloud bridge)
+# ---------------------------------------------------------------------------
+
+
+@strawberry.type
+class TenantSearchResult:
+    """A fuzzy-matched tenant returned by ``Query.searchTenants``.
+
+    ``score`` is a 0-100 hint for the caller — 100 means an exact email or
+    phone match, 50 means the query was a substring of the full name, 25
+    means it matched first or last name only.
+    """
+    tenant_id: str
+    name: str
+    score: int
+    email: typing.Optional[str] = None
+    phone: typing.Optional[str] = None
+    property_id: typing.Optional[str] = None
+    unit_label: typing.Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "TenantSearchResult":
+        return cls(
+            tenant_id=payload["tenant_id"],
+            name=payload["name"],
+            score=int(payload.get("score") or 0),
+            email=payload.get("email"),
+            phone=payload.get("phone"),
+            property_id=payload.get("property_id"),
+            unit_label=payload.get("unit_label"),
+        )
+
+
+@strawberry.input
+class ConversationTurnInput:
+    sender: str
+    text: str
+
+
+@strawberry.input
+class SuggestReplyInput:
+    """Payload the chrome extension sends for a one-shot reply draft."""
+    conversation_history: typing.List[ConversationTurnInput]
+    header_title: typing.Optional[str] = None
+    header_description: typing.Optional[str] = None
+    tenant_id: typing.Optional[str] = None
+    property_id: typing.Optional[str] = None
+
+
+@strawberry.type
+class SuggestReplyResult:
+    suggestion: str
+    matched_tenant: typing.Optional[TenantSearchResult] = None

--- a/www/rentmate-ui/src/graphql/generated.ts
+++ b/www/rentmate-ui/src/graphql/generated.ts
@@ -105,6 +105,11 @@ export type ConversationSummaryType = {
   updatedAt: Scalars['String']['output'];
 };
 
+export type ConversationTurnInput = {
+  sender: Scalars['String']['input'];
+  text: Scalars['String']['input'];
+};
+
 export type ConversationType =
   | 'SUGGESTION_AI'
   | 'TASK_AI'
@@ -284,6 +289,8 @@ export type Mutation = {
   simulateRoutine: Scalars['String']['output'];
   /** Spawn a Task from an existing conversation, linking lineage */
   spawnTask: TaskType;
+  /** One-shot agent-drafted reply for a TenantCloud conversation viewed in the chrome extension. Pure read on rentmate data — no DB writes. */
+  suggestReply: SuggestReplyResult;
   /** Update the agent context for any entity (property, unit, tenant, vendor) */
   updateEntityContext: Scalars['Boolean']['output'];
   /** Update a property's name, address, or type */
@@ -433,6 +440,11 @@ export type MutationSpawnTaskArgs = {
 };
 
 
+export type MutationSuggestReplyArgs = {
+  input: SuggestReplyInput;
+};
+
+
 export type MutationUpdateEntityContextArgs = {
   context: Scalars['String']['input'];
   entityId: Scalars['String']['input'];
@@ -502,6 +514,8 @@ export type Query = {
   routine: Maybe<RoutineType>;
   /** Returns all routines */
   routines: Array<RoutineType>;
+  /** Fuzzy-match tenants by name / email / phone. Top 3 ranked. */
+  searchTenants: Array<TenantSearchResult>;
   /** Returns suggestions, optionally filtered by status and/or document */
   suggestions: Array<SuggestionType>;
   /** Returns a single task by uid, including its full message thread */
@@ -552,6 +566,11 @@ export type QueryRoutineArgs = {
 
 export type QueryRoutinesArgs = {
   enabled?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type QuerySearchTenantsArgs = {
+  query: Scalars['String']['input'];
 };
 
 
@@ -613,6 +632,19 @@ export type SpawnTaskInput = {
   source: TaskSource;
   taskMode: TaskMode;
   urgency: InputMaybe<Urgency>;
+};
+
+export type SuggestReplyInput = {
+  conversationHistory: Array<ConversationTurnInput>;
+  headerDescription: InputMaybe<Scalars['String']['input']>;
+  headerTitle: InputMaybe<Scalars['String']['input']>;
+  propertyId: InputMaybe<Scalars['String']['input']>;
+  tenantId: InputMaybe<Scalars['String']['input']>;
+};
+
+export type SuggestReplyResult = {
+  matchedTenant: Maybe<TenantSearchResult>;
+  suggestion: Scalars['String']['output'];
 };
 
 export type SuggestionSource =
@@ -720,6 +752,16 @@ export type TaskType = {
   unreadCount: Scalars['Int']['output'];
   urgency: Maybe<Urgency>;
   vendorAssigned: Maybe<Scalars['String']['output']>;
+};
+
+export type TenantSearchResult = {
+  email: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  phone: Maybe<Scalars['String']['output']>;
+  propertyId: Maybe<Scalars['String']['output']>;
+  score: Scalars['Int']['output'];
+  tenantId: Scalars['String']['output'];
+  unitLabel: Maybe<Scalars['String']['output']>;
 };
 
 export type TenantType = {

--- a/www/rentmate-ui/src/graphql/schema.graphql
+++ b/www/rentmate-ui/src/graphql/schema.graphql
@@ -86,6 +86,11 @@ type ConversationSummaryType {
   taskTitle: String
 }
 
+input ConversationTurnInput {
+  sender: String!
+  text: String!
+}
+
 enum ConversationType {
   TENANT
   VENDOR
@@ -321,6 +326,11 @@ type Mutation {
 
   """Spawn a Task from an existing conversation, linking lineage"""
   spawnTask(input: SpawnTaskInput!): TaskType!
+
+  """
+  One-shot agent-drafted reply for a TenantCloud conversation viewed in the chrome extension. Pure read on rentmate data — no DB writes.
+  """
+  suggestReply(input: SuggestReplyInput!): SuggestReplyResult!
 }
 
 type Query {
@@ -371,6 +381,9 @@ type Query {
 
   """Returns conversations by type (tenant/vendor/user_ai/task_ai)"""
   conversations(conversationType: ConversationType!, limit: Int! = 50, offset: Int! = 0): [ConversationSummaryType!]!
+
+  """Fuzzy-match tenants by name / email / phone. Top 3 ranked."""
+  searchTenants(query: String!): [TenantSearchResult!]!
 }
 
 enum RoutineState {
@@ -414,6 +427,19 @@ input SpawnTaskInput {
   priority: TaskPriority = null
   taskMode: TaskMode! = AUTONOMOUS
   source: TaskSource! = MANUAL
+}
+
+input SuggestReplyInput {
+  conversationHistory: [ConversationTurnInput!]!
+  headerTitle: String = null
+  headerDescription: String = null
+  tenantId: String = null
+  propertyId: String = null
+}
+
+type SuggestReplyResult {
+  suggestion: String!
+  matchedTenant: TenantSearchResult
 }
 
 enum SuggestionSource {
@@ -527,6 +553,16 @@ type TaskType {
   lastReviewSummary: String
   lastReviewNextStep: String
   unreadCount: Int!
+}
+
+type TenantSearchResult {
+  tenantId: String!
+  name: String!
+  score: Int!
+  email: String
+  phone: String
+  propertyId: String
+  unitLabel: String
 }
 
 type TenantType {


### PR DESCRIPTION
## Summary

Login already exists as a GraphQL mutation, so this round-trips the extension through one unified API surface — no new REST.

### \`Query.searchTenants(query: String!): [TenantSearchResult!]!\`

Fuzzy match over the org's active tenants by name / email / phone. Returns the top 3 ranked. Score 100 = exact email/phone, 50 = full-name substring, 25 = first-or-last-name substring, others drop. Backed by \`gql/services/extension_service.rank_tenants\`, which reuses \`db.queries.fetch_tenants\`.

### \`Mutation.suggestReply(input: SuggestReplyInput!): SuggestReplyResult!\`

Single LiteLLM completion (no agent loop, no tools, **no DB writes**) that drafts an SMS-style reply for the TenantCloud conversation the PM is currently looking at. When \`tenantId\` is supplied, the system prompt inlines the tenant's name + unit so the draft is appropriately addressed; the mutation echoes the matched tenant back in \`matchedTenant\` so the extension UI can display it. Falls back to a canned \`\"I'll follow up on this shortly.\"\` on any LLM error so the extension never crashes.

Implementation pattern lifted from \`demo/simulator.py:_generate_reply\`.

## Test plan

- [x] \`poetry run pytest gql/services/tests/test_extension_service.py gql/tests/test_extension_schema.py -q\` — 14/14 pass
- [x] \`poetry run pytest gql/services/tests/ gql/tests/ -q\` — 82/82 pass (1 unrelated pre-existing deselect)

## Companion / follow-ups

- **rentmate-hosted PR (next)**: bumps the rentmate pin to this SHA, rewrites the chrome extension to call the new GraphQL surface, adds CORS for \`chrome-extension://*\`. Cannot land before this merges.
- **Out of scope**: mirroring TenantCloud chats into rentmate as read-only conversations. Captured for a follow-up — needs a new \`ConversationType.TENANTCLOUD_MIRROR\`, a mirror mutation, and a read-only guard at message-send time.