### PR TITLE
Set request context inside _agent_task_autoreply_inner

### DIFF
--- a/handlers/chat.py
+++ b/handlers/chat.py
@@ -702,9 +702,11 @@ def agent_task_autoreply(task_id: str, hint: str | None = None) -> str | None:
 
 def _agent_task_autoreply_inner(task_id: str, hint: str | None = None) -> str | None:
 
+    from backends.local_auth import reset_request_context, set_request_context
     from llm.client import call_agent
 
     db = SessionLocal.session_factory()
+    ctx_token = None
     try:
         task = db.query(Task).filter_by(id=task_id).first()
         if not task:
@@ -712,6 +714,17 @@ def _agent_task_autoreply_inner(task_id: str, hint: str | None = None) -> str | 
         conv = task.ai_conversation
         if not conv:
             return None
+
+        # Background callers (reply_scanner, portal autoreply daemon
+        # threads, demo simulator) never went through HTTP auth, so
+        # the request context is empty and any DB query downstream
+        # that calls ``resolve_account_id`` would raise. Derive the
+        # context from the task we just loaded and pin it for the
+        # rest of this autoreply.
+        ctx_token = set_request_context(
+            account_id=task.creator_id,
+            org_id=task.org_id,
+        )
 
         # Change detection: skip if nothing changed since the last reply scan
         current_hash = _compute_autoreply_hash(task)
@@ -854,6 +867,8 @@ def _agent_task_autoreply_inner(task_id: str, hint: str | None = None) -> str | 
         log_trace("error", "reply_scanner", f"Reply scan failed: {e}")
         return None
     finally:
+        if ctx_token is not None:
+            reset_request_context(ctx_token)
         db.close()
 
 ASSESS_PROMPT = (

--- a/handlers/tests/test_autoreply_context.py
+++ b/handlers/tests/test_autoreply_context.py
@@ -1,0 +1,88 @@
+"""Regression tests for the request-context bug in
+``handlers.chat._agent_task_autoreply_inner``.
+
+Background callers (reply_scanner loop, portal autoreply daemon
+thread, demo simulator) invoke ``agent_task_autoreply`` without
+having gone through HTTP auth. Before the fix, the first downstream
+call to ``resolve_account_id`` blew up with
+``RuntimeError: No account context set …``.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from backends.local_auth import reset_request_context, resolve_account_id, resolve_org_id, set_request_context
+from db.enums import TaskStatus
+from db.models import Conversation, ConversationType, Task
+from gql.services.number_allocator import NumberAllocator
+from handlers.chat import _agent_task_autoreply_inner
+
+
+def _seed_task(db, *, creator_id=1, org_id=1):
+    convo = Conversation(
+        org_id=org_id, creator_id=creator_id, subject="Auto",
+        conversation_type=ConversationType.TASK_AI,
+        is_group=False, is_archived=False,
+    )
+    db.add(convo)
+    db.flush()
+    task = Task(
+        id=NumberAllocator.allocate_next(db, entity_type="task", org_id=org_id),
+        org_id=org_id, creator_id=creator_id,
+        title="Test", task_status=TaskStatus.ACTIVE,
+        ai_conversation_id=convo.id,
+    )
+    db.add(task)
+    db.flush()
+    return task
+
+
+def test_autoreply_inner_sets_request_context_from_task(db):
+    """Without prior HTTP auth, the inner autoreply must derive
+    creator_id + org_id from the task and seed the request context
+    so the next ``resolve_account_id`` call succeeds."""
+    task = _seed_task(db, creator_id=1, org_id=1)
+    db.commit()
+
+    captured = {}
+
+    def _fake_compute_hash(_t):
+        # Prove the request context is live by the time we get past
+        # the task lookup. ``resolve_account_id`` would raise without
+        # the fix.
+        captured["account_id"] = resolve_account_id()
+        captured["org_id"] = resolve_org_id()
+        return "stub-hash"
+
+    with patch("db.session.SessionLocal.session_factory", return_value=db), \
+         patch.object(db, "close", lambda: None), \
+         patch("handlers.chat._compute_autoreply_hash", side_effect=_fake_compute_hash), \
+         patch("handlers.chat._autoreply_state", {str(task.id): "stub-hash"}):
+        # Same hash → returns None early (before kicking off the agent).
+        # That's fine — we only care that the context was set in
+        # ``_compute_autoreply_hash``.
+        result = _agent_task_autoreply_inner(str(task.id))
+
+    assert result is None
+    assert captured == {"account_id": 1, "org_id": 1}
+
+
+def test_autoreply_inner_resets_request_context_on_exit(db):
+    """After the inner autoreply returns, the caller's prior context
+    (or empty) must be restored. Otherwise per-task context would
+    leak across reply_scanner loop iterations."""
+    task = _seed_task(db, creator_id=1, org_id=1)
+    db.commit()
+
+    # Pre-seed a different context so we can verify it's restored.
+    pre_token = set_request_context(account_id=999, org_id=999)
+    try:
+        with patch("db.session.SessionLocal.session_factory", return_value=db), \
+             patch.object(db, "close", lambda: None), \
+             patch("handlers.chat._compute_autoreply_hash", return_value="stub-hash"), \
+             patch("handlers.chat._autoreply_state", {str(task.id): "stub-hash"}):
+            _agent_task_autoreply_inner(str(task.id))
+        assert resolve_account_id() == 999
+        assert resolve_org_id() == 999
+    finally:
+        reset_request_context(pre_token)


### PR DESCRIPTION
## Summary

Fixes a runtime crash in the background autoreply path:

\`\`\`
[reply_scanner] Failed for task 6: No account context set — did the request go through authentication?
  File "/usr/local/lib/python3.12/site-packages/handlers/chat.py", line 736, in _agent_task_autoreply_inner
    context = build_task_context(db, task_id, query=hint or default_hint)
  …
  File "/usr/local/lib/python3.12/site-packages/backends/local_auth.py", line 42, in resolve_account_id
    raise RuntimeError("No account context set — did the request go through authentication?")
\`\`\`

Background callers — \`reply_scanner_loop\`, the portal autoreply daemon thread (\`handlers/portals/_common.py:trigger_task_autoreply\`), the new demo simulator — invoke \`agent_task_autoreply\` without having gone through HTTP auth, so the request contextvars (\`account_id\` / \`org_id\`) are empty. The first downstream call to \`resolve_account_id\` then explodes.

Fix is one place: \`_agent_task_autoreply_inner\` already loads the \`Task\` row up front, so it knows the right \`creator_id\` + \`org_id\`. Pin the request context with those values right after the task lookup, restore the prior context on exit. Every caller benefits without touching their own scheduling code.

## Test plan

- [x] \`poetry run pytest handlers/tests/test_autoreply_context.py -q\` — 2/2 pass.
- [ ] CI green
- [x] Manual: hosted dev (\`npm run dev\`) — reply scanner sweep no longer logs the \`No account context set\` traceback.