### PR TITLE
suggestReply: surface LLM errors instead of silent fallback

### DIFF
--- a/gql/schema.py
+++ b/gql/schema.py
@@ -834,6 +834,8 @@ class Mutation(AuthMutation):
         return SuggestReplyResult(
             suggestion=result["suggestion"],
             matched_tenant=TenantSearchResult.from_dict(matched) if matched else None,
+            error=result.get("error"),
+            fallback=bool(result.get("fallback")),
         )
 
 

--- a/gql/services/extension_service.py
+++ b/gql/services/extension_service.py
@@ -157,6 +157,29 @@ def _build_user_message(history: list[dict[str, str]]) -> str:
     )
 
 
+def _classify_llm_error(exc: Exception) -> str:
+    """Map a LiteLLM failure to a short, actionable user-facing string.
+    The chrome extension renders this verbatim so PMs know whether the
+    hosted LLM is mis-configured (auth, model, base URL) vs. a transient
+    blip worth retrying."""
+    name = type(exc).__name__
+    msg = str(exc).lower()
+    if "authentication" in name.lower() or "incorrect api key" in msg or "401" in msg:
+        return "Hosted LLM rejected the API key. Check LLM_API_KEY in the rentmate Cloud Run service."
+    if "model" in msg and ("not found" in msg or "does not exist" in msg or "invalid" in msg):
+        return "Hosted LLM doesn't recognise the configured model. Check LLM_MODEL."
+    if "rate" in msg and "limit" in msg or "429" in msg:
+        return "Hosted LLM is rate-limiting. Try again in a moment."
+    if "timeout" in msg or "timed out" in msg:
+        return "Hosted LLM timed out. Try again."
+    if "connection" in msg or "could not reach" in msg or "unreachable" in msg:
+        return "Hosted LLM endpoint unreachable. Check LLM_BASE_URL."
+    # Generic — include a short prefix of the upstream error so support
+    # has something to grep without leaking full tracebacks to the UI.
+    detail = str(exc)[:160]
+    return f"Hosted LLM error: {detail}"
+
+
 async def draft_reply(
     db: Any,
     *,
@@ -167,7 +190,9 @@ async def draft_reply(
     property_id: str | None,
 ) -> dict[str, Any]:
     """Run a single LiteLLM completion and return the drafted reply +
-    matched-tenant echo. Falls back to a canned reply on any LLM error."""
+    matched-tenant echo. On any LLM error, populate ``error`` and
+    ``fallback`` so the chrome extension can surface a real banner
+    instead of pretending the canned reply is a draft."""
     import litellm
 
     from llm.model_config import build_litellm_request_kwargs
@@ -203,6 +228,16 @@ async def draft_reply(
         suggestion = suggestion[:500]
     except Exception as exc:  # noqa: BLE001
         logger.warning("[extension] suggestReply LLM failed; using canned: %s", exc)
-        suggestion = _FALLBACK_REPLY
+        return {
+            "suggestion": _FALLBACK_REPLY,
+            "matched_tenant": matched_tenant,
+            "error": _classify_llm_error(exc),
+            "fallback": True,
+        }
 
-    return {"suggestion": suggestion, "matched_tenant": matched_tenant}
+    return {
+        "suggestion": suggestion,
+        "matched_tenant": matched_tenant,
+        "error": None,
+        "fallback": False,
+    }

--- a/gql/services/tests/test_extension_service.py
+++ b/gql/services/tests/test_extension_service.py
@@ -163,7 +163,7 @@ def test_draft_reply_includes_tenant_name_in_system_prompt(db):
 
 def test_draft_reply_falls_back_on_llm_error(db):
     with _request_scope():
-        with patch("litellm.acompletion", new_callable=AsyncMock, side_effect=RuntimeError("network")):
+        with patch("litellm.acompletion", new_callable=AsyncMock, side_effect=RuntimeError("connection refused")):
             result = asyncio.run(draft_reply(
                 db,
                 conversation_history=[{"sender": "Tenant", "text": "Hi?"}],
@@ -175,6 +175,57 @@ def test_draft_reply_falls_back_on_llm_error(db):
 
     assert result["suggestion"] == _FALLBACK_REPLY
     assert result["matched_tenant"] is None
+    assert result["fallback"] is True
+    # Connection-style failures get the "endpoint unreachable" message,
+    # not a generic LLM error blob.
+    assert result["error"] is not None
+    assert "unreachable" in result["error"].lower() or "base url" in result["error"].lower()
+
+
+def test_draft_reply_classifies_auth_error(db):
+    """The exact error PMs hit when the OpenAI/OpenRouter key is wrong
+    deserves an actionable message that names the env var."""
+    class FakeAuthError(Exception):
+        pass
+    FakeAuthError.__name__ = "AuthenticationError"
+
+    with _request_scope():
+        with patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=FakeAuthError("Incorrect API key provided: sk-xxx"),
+        ):
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "T", "text": "hi"}],
+                header_title=None, header_description=None,
+                tenant_id=None, property_id=None,
+            ))
+
+    assert result["fallback"] is True
+    assert "LLM_API_KEY" in result["error"]
+
+
+def test_draft_reply_success_has_no_error(db):
+    """Happy path doesn't set ``error`` or ``fallback`` so the extension
+    can trust the suggestion."""
+    with _request_scope():
+        async def fake_acompletion(*_args, **_kwargs):
+            fake = MagicMock()
+            fake.choices = [MagicMock(message=MagicMock(content="A real reply."))]
+            return fake
+
+        with patch("litellm.acompletion", side_effect=fake_acompletion):
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "T", "text": "hi"}],
+                header_title=None, header_description=None,
+                tenant_id=None, property_id=None,
+            ))
+
+    assert result["suggestion"] == "A real reply."
+    assert result["fallback"] is False
+    assert result["error"] is None
 
 
 def test_draft_reply_clamps_long_completion(db):

--- a/gql/types.py
+++ b/gql/types.py
@@ -1225,3 +1225,9 @@ class SuggestReplyInput:
 class SuggestReplyResult:
     suggestion: str
     matched_tenant: typing.Optional[TenantSearchResult] = None
+    # Set when the LLM call failed and ``suggestion`` is the canned
+    # placeholder. The chrome extension shows ``error`` verbatim in a
+    # banner so a misconfigured hosted LLM is visible immediately,
+    # rather than silently shipping fake-looking drafts.
+    error: typing.Optional[str] = None
+    fallback: bool = False

--- a/www/rentmate-ui/src/graphql/generated.ts
+++ b/www/rentmate-ui/src/graphql/generated.ts
@@ -643,6 +643,8 @@ export type SuggestReplyInput = {
 };
 
 export type SuggestReplyResult = {
+  error: Maybe<Scalars['String']['output']>;
+  fallback: Scalars['Boolean']['output'];
   matchedTenant: Maybe<TenantSearchResult>;
   suggestion: Scalars['String']['output'];
 };

--- a/www/rentmate-ui/src/graphql/schema.graphql
+++ b/www/rentmate-ui/src/graphql/schema.graphql
@@ -440,6 +440,8 @@ input SuggestReplyInput {
 type SuggestReplyResult {
   suggestion: String!
   matchedTenant: TenantSearchResult
+  error: String
+  fallback: Boolean!
 }
 
 enum SuggestionSource {


### PR DESCRIPTION
## Summary

The PM saw what looked like a real (terrible) draft and had no idea the hosted LLM was broken. 

## Schema change

\`SuggestReplyResult\` gains two optional fields, existing ones unchanged:

\`\`\`graphql
type SuggestReplyResult {
  suggestion: String!
  matchedTenant: TenantSearchResult
  error: String                # human-readable, e.g. "Hosted LLM rejected the API key…"
  fallback: Boolean!           # true when suggestion is the canned placeholder
}
\`\`\`

## Error classifier

\`_classify_llm_error\` maps common LiteLLM failures to actionable PM-facing copy:

| LiteLLM failure | Surfaced message |
|---|---|
| \`AuthenticationError\` / "Incorrect API key" / 401 | "Hosted LLM rejected the API key. Check LLM_API_KEY in the rentmate Cloud Run service." |
| invalid model / model not found | "Hosted LLM doesn't recognise the configured model. Check LLM_MODEL." |
| 429 / rate limit | "Hosted LLM is rate-limiting. Try again in a moment." |
| timeout | "Hosted LLM timed out. Try again." |
| connection refused / unreachable | "Hosted LLM endpoint unreachable. Check LLM_BASE_URL." |
| anything else | "Hosted LLM error: \<first 160 chars\>" |

The chrome extension renders \`error\` verbatim in the suggestion box so misconfig is visible immediately. Companion hosted PR will wire the renderer.

## Test plan

- [x] \`poetry run pytest gql/services/tests/test_extension_service.py gql/tests/test_extension_schema.py -q\` — 16 pass (14 existing + 2 new: classifier auth-error message, happy-path null fields).
- [x] \`poetry run pytest tests/test_graphql_codegen.py -q\` — codegen artifacts regenerated; passes.
- [ ] CI green