### PR TITLE
suggestReply: route through agent + mirror external thread read-only

### DIFF
--- a/db/models/messaging.py
+++ b/db/models/messaging.py
@@ -32,10 +32,9 @@ class ConversationType(str, Enum):
     USER_AI       = "user_ai"
     TASK_AI       = "task_ai"
     SUGGESTION_AI = "suggestion_ai"
-    # Read-only snapshot of a thread mirrored from another platform
-    # (TenantCloud is the only source today). Replies happen back on
-    # the source platform — rentmate's send-message paths refuse to
-    # write into these conversations.
+    # Read-only snapshot of a thread mirrored from an external chat
+    # platform. Replies happen back on the source platform — rentmate's
+    # send-message paths refuse to write into these conversations.
     MIRRORED_CHAT = "mirrored_chat"
 
 

--- a/db/models/messaging.py
+++ b/db/models/messaging.py
@@ -27,12 +27,16 @@ class ParticipantType(str, Enum):
 
 
 class ConversationType(str, Enum):
-    TENANT             = "tenant"
-    VENDOR             = "vendor"
-    USER_AI            = "user_ai"
-    TASK_AI            = "task_ai"
-    SUGGESTION_AI      = "suggestion_ai"
-    TENANTCLOUD_MIRROR = "tenantcloud_mirror"
+    TENANT        = "tenant"
+    VENDOR        = "vendor"
+    USER_AI       = "user_ai"
+    TASK_AI       = "task_ai"
+    SUGGESTION_AI = "suggestion_ai"
+    # Read-only snapshot of a thread mirrored from another platform
+    # (TenantCloud is the only source today). Replies happen back on
+    # the source platform — rentmate's send-message paths refuse to
+    # write into these conversations.
+    MIRRORED_CHAT = "mirrored_chat"
 
 
 class MessageType(int, Enum):

--- a/db/models/messaging.py
+++ b/db/models/messaging.py
@@ -27,11 +27,12 @@ class ParticipantType(str, Enum):
 
 
 class ConversationType(str, Enum):
-    TENANT        = "tenant"
-    VENDOR        = "vendor"
-    USER_AI       = "user_ai"
-    TASK_AI       = "task_ai"
-    SUGGESTION_AI = "suggestion_ai"
+    TENANT             = "tenant"
+    VENDOR             = "vendor"
+    USER_AI            = "user_ai"
+    TASK_AI            = "task_ai"
+    SUGGESTION_AI      = "suggestion_ai"
+    TENANTCLOUD_MIRROR = "tenantcloud_mirror"
 
 
 class MessageType(int, Enum):

--- a/gql/schema.py
+++ b/gql/schema.py
@@ -813,8 +813,11 @@ class Mutation(AuthMutation):
         return TaskType.from_sql(task)
 
     @strawberry.mutation(description=(
-        "One-shot agent-drafted reply for a TenantCloud conversation viewed "
-        "in the chrome extension. Pure read on rentmate data — no DB writes."
+        "Agent-drafted reply for a TenantCloud conversation viewed in the "
+        "chrome extension. When ``externalThreadId`` is provided the thread "
+        "is mirrored into rentmate as a read-only conversation so the "
+        "AgentRun is groupable in DevTools and re-clicking ``Suggest`` "
+        "doesn't duplicate messages."
     ))
     async def suggest_reply(self, info: Info, *, input: SuggestReplyInput) -> SuggestReplyResult:
         from gql.services.extension_service import draft_reply
@@ -829,6 +832,7 @@ class Mutation(AuthMutation):
             header_description=input.header_description,
             tenant_id=input.tenant_id,
             property_id=input.property_id,
+            external_thread_id=input.external_thread_id,
         )
         matched = result.get("matched_tenant")
         return SuggestReplyResult(
@@ -836,6 +840,7 @@ class Mutation(AuthMutation):
             matched_tenant=TenantSearchResult.from_dict(matched) if matched else None,
             error=result.get("error"),
             fallback=bool(result.get("fallback")),
+            conversation_external_id=result.get("conversation_external_id"),
         )
 
 

--- a/gql/schema.py
+++ b/gql/schema.py
@@ -833,6 +833,7 @@ class Mutation(AuthMutation):
             tenant_id=input.tenant_id,
             property_id=input.property_id,
             external_thread_id=input.external_thread_id,
+            draft_text=input.draft_text,
         )
         matched = result.get("matched_tenant")
         return SuggestReplyResult(

--- a/gql/schema.py
+++ b/gql/schema.py
@@ -813,11 +813,11 @@ class Mutation(AuthMutation):
         return TaskType.from_sql(task)
 
     @strawberry.mutation(description=(
-        "Agent-drafted reply for a TenantCloud conversation viewed in the "
-        "chrome extension. When ``externalThreadId`` is provided the thread "
-        "is mirrored into rentmate as a read-only conversation so the "
-        "AgentRun is groupable in DevTools and re-clicking ``Suggest`` "
-        "doesn't duplicate messages."
+        "Agent-drafted reply for a conversation in an external chat tool, "
+        "viewed via the chrome extension. When ``externalThreadId`` is "
+        "provided the thread is mirrored into rentmate as a read-only "
+        "conversation so the AgentRun is groupable in DevTools and "
+        "re-clicking ``Suggest`` doesn't duplicate messages."
     ))
     async def suggest_reply(self, info: Info, *, input: SuggestReplyInput) -> SuggestReplyResult:
         from gql.services.extension_service import draft_reply
@@ -834,6 +834,7 @@ class Mutation(AuthMutation):
             property_id=input.property_id,
             external_thread_id=input.external_thread_id,
             draft_text=input.draft_text,
+            source=input.source,
         )
         matched = result.get("matched_tenant")
         return SuggestReplyResult(

--- a/gql/services/chat_service.py
+++ b/gql/services/chat_service.py
@@ -416,8 +416,8 @@ def send_autonomous_message(
     if convo.conversation_type == ConversationType.MIRRORED_CHAT:
         from gql.services.extension_service import MirrorConversationReadOnly
         raise MirrorConversationReadOnly(
-            f"Conversation {conversation_id} mirrors a TenantCloud thread; "
-            "replies must be sent via TenantCloud."
+            f"Conversation {conversation_id} mirrors an external chat thread; "
+            "replies must be sent on the source platform."
         )
 
     msg = Message(
@@ -557,8 +557,8 @@ def send_message(
     if convo is not None and convo.conversation_type == ConversationType.MIRRORED_CHAT:
         from gql.services.extension_service import MirrorConversationReadOnly
         raise MirrorConversationReadOnly(
-            f"Conversation {conversation_id} mirrors a TenantCloud thread; "
-            "replies must be sent via TenantCloud."
+            f"Conversation {conversation_id} mirrors an external chat thread; "
+            "replies must be sent on the source platform."
         )
     now = sent_at or datetime.now(UTC)
     msg = Message(

--- a/gql/services/chat_service.py
+++ b/gql/services/chat_service.py
@@ -413,6 +413,12 @@ def send_autonomous_message(
     ).first()
     if not convo:
         raise ValueError(f"Conversation {conversation_id} not found")
+    if convo.conversation_type == ConversationType.TENANTCLOUD_MIRROR:
+        from gql.services.extension_service import MirrorConversationReadOnly
+        raise MirrorConversationReadOnly(
+            f"Conversation {conversation_id} mirrors a TenantCloud thread; "
+            "replies must be sent via TenantCloud."
+        )
 
     msg = Message(
         org_id=resolve_org_id(),
@@ -547,6 +553,13 @@ def send_message(
     sent_at: datetime | None = None,
 ) -> Message:
     """Add a message to any conversation by conversation_id."""
+    convo = db.query(Conversation).filter_by(id=conversation_id).first()
+    if convo is not None and convo.conversation_type == ConversationType.TENANTCLOUD_MIRROR:
+        from gql.services.extension_service import MirrorConversationReadOnly
+        raise MirrorConversationReadOnly(
+            f"Conversation {conversation_id} mirrors a TenantCloud thread; "
+            "replies must be sent via TenantCloud."
+        )
     now = sent_at or datetime.now(UTC)
     msg = Message(
         org_id=resolve_org_id(),

--- a/gql/services/chat_service.py
+++ b/gql/services/chat_service.py
@@ -413,7 +413,7 @@ def send_autonomous_message(
     ).first()
     if not convo:
         raise ValueError(f"Conversation {conversation_id} not found")
-    if convo.conversation_type == ConversationType.TENANTCLOUD_MIRROR:
+    if convo.conversation_type == ConversationType.MIRRORED_CHAT:
         from gql.services.extension_service import MirrorConversationReadOnly
         raise MirrorConversationReadOnly(
             f"Conversation {conversation_id} mirrors a TenantCloud thread; "
@@ -554,7 +554,7 @@ def send_message(
 ) -> Message:
     """Add a message to any conversation by conversation_id."""
     convo = db.query(Conversation).filter_by(id=conversation_id).first()
-    if convo is not None and convo.conversation_type == ConversationType.TENANTCLOUD_MIRROR:
+    if convo is not None and convo.conversation_type == ConversationType.MIRRORED_CHAT:
         from gql.services.extension_service import MirrorConversationReadOnly
         raise MirrorConversationReadOnly(
             f"Conversation {conversation_id} mirrors a TenantCloud thread; "

--- a/gql/services/extension_service.py
+++ b/gql/services/extension_service.py
@@ -1,14 +1,18 @@
 """Helpers for the GraphQL fields the chrome extension calls.
 
-Two responsibilities:
+Three responsibilities:
 
 - ``rank_tenants`` — fuzzy-search the org's active tenants by name, email,
   or phone. Used by the extension to map a TenantCloud sender name onto a
   rentmate tenant id before drafting a reply.
-- ``draft_reply`` — one-shot LiteLLM completion that returns an SMS-style
-  reply for the conversation the PM is looking at in TenantCloud. No DB
-  writes, no agent loop, no tools. On any LLM error it falls back to a
-  canned acknowledgement so the extension never crashes.
+- ``draft_reply`` — drive the actual rentmate agent over a TenantCloud
+  conversation and return its drafted reply. The thread is mirrored into
+  rentmate as a read-only ``TENANTCLOUD_MIRROR`` Conversation so DevTools
+  can show the AgentRun, and so re-clicking "Suggest" for the same thread
+  doesn't duplicate the mirrored history.
+- ``MirrorConversationReadOnly`` — exception raised when something tries to
+  send a new message into a mirror conversation; the inbound history is
+  authoritative, replies happen back in TenantCloud.
 
 Both helpers run inside a request context that already has org/account
 ids resolved (subdomain middleware / JWT auth), so they don't take ids
@@ -18,8 +22,20 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import UTC, datetime
 from typing import Any
 
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from backends.local_auth import resolve_account_id, resolve_org_id
+from db.models import (
+    Conversation,
+    ConversationType,
+    Message,
+    MessageType,
+    ParticipantType,
+)
 from db.queries import fetch_tenants
 
 logger = logging.getLogger("rentmate.gql.extension")
@@ -31,6 +47,19 @@ _EXACT_MATCH_SCORE = 100
 _FULL_NAME_MATCH_SCORE = 50
 _PARTIAL_NAME_MATCH_SCORE = 25
 _MAX_RESULTS = 3
+
+# Lowercase tokens TenantCloud uses for the property manager themselves.
+# Used to map a scraped sender name onto ParticipantType.ACCOUNT_USER vs
+# EXTERNAL_CONTACT when mirroring messages.
+_PM_SENDER_TOKENS = ("you", "property manager", "manager")
+
+
+class MirrorConversationReadOnly(Exception):
+    """Raised when send-message paths target a TENANTCLOUD_MIRROR Conversation.
+
+    The inbound TenantCloud thread is the authoritative source for both
+    PM and tenant turns; new replies happen in TenantCloud, not rentmate.
+    """
 
 
 def _score_tenant(tenant: Any, query: str) -> int:
@@ -118,13 +147,177 @@ def _resolve_tenant_for_reply(db: Any, tenant_id: str | None) -> dict[str, Any] 
     return None
 
 
-def _build_system_prompt(*, tenant_payload: dict[str, Any] | None, header_title: str | None, header_description: str | None) -> str:
+def _is_pm_sender(sender: str | None) -> bool:
+    return (sender or "").strip().lower() in _PM_SENDER_TOKENS
+
+
+def _find_mirror_conversation(db: Session, *, external_thread_id: str) -> Conversation | None:
+    """Look up the read-only TenantCloud mirror for this thread, if any.
+
+    Stored in ``Conversation.extra->>'external_thread_id'`` so two threads
+    with the same TenantCloud URL don't collide and so we can dedup
+    messages on a re-import without scanning every conversation in the org.
+    """
+    rows = (
+        db.query(Conversation)
+        .filter_by(
+            org_id=resolve_org_id(),
+            creator_id=resolve_account_id(),
+            conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+        )
+        .all()
+    )
+    for conv in rows:
+        extra = conv.extra or {}
+        if str(extra.get("external_thread_id") or "") == str(external_thread_id):
+            return conv
+    return None
+
+
+def _upsert_mirror_conversation(
+    db: Session,
+    *,
+    external_thread_id: str,
+    header_title: str | None,
+    header_description: str | None,
+    tenant_payload: dict[str, Any] | None,
+    property_id: str | None,
+) -> Conversation:
+    """Find or create the read-only mirror Conversation for a TenantCloud thread.
+
+    The conversation is keyed by ``external_thread_id`` (typically the
+    scraped TenantCloud URL pathname) so re-clicking ``Suggest`` for the
+    same thread reuses the existing row instead of spawning duplicates.
+    """
+    conv = _find_mirror_conversation(db, external_thread_id=external_thread_id)
+    now = datetime.now(UTC)
+    subject = (header_title or "").strip() or "TenantCloud thread"
+    if conv is None:
+        extra = {
+            "source": "tenantcloud",
+            "external_thread_id": str(external_thread_id),
+            "read_only": True,
+        }
+        if tenant_payload:
+            extra["matched_tenant_id"] = tenant_payload.get("tenant_id")
+        if header_description:
+            extra["header_description"] = header_description
+        conv = Conversation(
+            org_id=resolve_org_id(),
+            creator_id=resolve_account_id(),
+            subject=subject[:255],
+            property_id=property_id or (tenant_payload or {}).get("property_id"),
+            conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+            is_group=False,
+            is_archived=False,
+            extra=extra,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(conv)
+        db.flush()
+        return conv
+
+    extra = dict(conv.extra or {})
+    changed = False
+    if header_description and extra.get("header_description") != header_description:
+        extra["header_description"] = header_description
+        changed = True
+    if tenant_payload and not extra.get("matched_tenant_id"):
+        extra["matched_tenant_id"] = tenant_payload.get("tenant_id")
+        changed = True
+    if changed:
+        conv.extra = extra
+        flag_modified(conv, "extra")
+    if subject and conv.subject != subject[:255]:
+        conv.subject = subject[:255]
+    conv.updated_at = now
+    db.flush()
+    return conv
+
+
+def _existing_mirror_indices(conv: Conversation) -> set[int]:
+    """Indices of TenantCloud turns already mirrored on this conversation.
+
+    Each mirrored Message stores its zero-based position inside the
+    TenantCloud thread under ``meta.tenantcloud_index``. The set is used
+    to skip turns that were imported on a previous ``Suggest`` click.
+    """
+    indices: set[int] = set()
+    for msg in conv.messages or []:
+        meta = msg.meta or {}
+        idx = meta.get("tenantcloud_index")
+        if isinstance(idx, int):
+            indices.add(idx)
+    return indices
+
+
+def _sync_mirror_messages(
+    db: Session,
+    *,
+    conv: Conversation,
+    conversation_history: list[dict[str, str]],
+) -> int:
+    """Insert any TenantCloud turns we haven't mirrored yet.
+
+    Dedup is position-based: TenantCloud always renders a thread
+    chronologically, so the n-th turn is stable across scrapes. Each
+    mirrored Message records ``meta.tenantcloud_index = n``; turns whose
+    index is already on the conversation are skipped. Returns the number
+    of messages newly inserted.
+    """
+    if not conversation_history:
+        return 0
+    existing = _existing_mirror_indices(conv)
+    inserted = 0
+    now = datetime.now(UTC)
+    for idx, turn in enumerate(conversation_history):
+        if idx in existing:
+            continue
+        text = (turn.get("text") or "").strip()
+        if not text:
+            continue
+        sender = (turn.get("sender") or "").strip() or "Tenant"
+        is_pm = _is_pm_sender(sender)
+        msg = Message(
+            org_id=resolve_org_id(),
+            conversation_id=conv.id,
+            sender_type=(
+                ParticipantType.ACCOUNT_USER if is_pm else ParticipantType.EXTERNAL_CONTACT
+            ),
+            sender_id=None,
+            body=text,
+            message_type=MessageType.MESSAGE,
+            sender_name=sender[:255],
+            is_ai=False,
+            is_system=False,
+            meta={
+                "source": "tenantcloud",
+                "tenantcloud_index": idx,
+                "direction": "outbound" if is_pm else "inbound",
+            },
+            sent_at=now,
+        )
+        db.add(msg)
+        inserted += 1
+    if inserted:
+        conv.updated_at = now
+    return inserted
+
+
+def _build_system_prompt(
+    *,
+    tenant_payload: dict[str, Any] | None,
+    header_title: str | None,
+    header_description: str | None,
+) -> str:
     intro = (
         "You are RentMate drafting a reply on behalf of the property "
         "manager. The PM is composing a response to a tenant inside "
         "TenantCloud. Draft a single SMS-style reply, 1-3 sentences, "
         "warm and professional. Do not invent facts or commit to dates. "
-        "Do not mention RentMate or that you are an AI."
+        "Do not mention RentMate or that you are an AI. Output only the "
+        "reply text, no labels."
     )
     parts: list[str] = [intro]
     if tenant_payload:
@@ -152,16 +345,15 @@ def _build_user_message(history: list[dict[str, str]]) -> str:
         "Recent conversation between the property manager and the tenant "
         "(most recent last):\n\n"
         f"{transcript}\n\n"
-        "Draft the property manager's next reply. Output only the reply "
-        "text, no labels."
+        "Draft the property manager's next reply."
     )
 
 
 def _classify_llm_error(exc: Exception) -> str:
-    """Map a LiteLLM failure to a short, actionable user-facing string.
-    The chrome extension renders this verbatim so PMs know whether the
-    hosted LLM is mis-configured (auth, model, base URL) vs. a transient
-    blip worth retrying."""
+    """Map a LiteLLM / agent failure to a short, actionable user-facing
+    string. The chrome extension renders this verbatim so PMs know
+    whether the hosted LLM is mis-configured (auth, model, base URL) vs.
+    a transient blip worth retrying."""
     name = type(exc).__name__
     msg = str(exc).lower()
     if "authentication" in name.lower() or "incorrect api key" in msg or "401" in msg:
@@ -174,10 +366,80 @@ def _classify_llm_error(exc: Exception) -> str:
         return "Hosted LLM timed out. Try again."
     if "connection" in msg or "could not reach" in msg or "unreachable" in msg:
         return "Hosted LLM endpoint unreachable. Check LLM_BASE_URL."
-    # Generic — include a short prefix of the upstream error so support
-    # has something to grep without leaking full tracebacks to the UI.
     detail = str(exc)[:160]
     return f"Hosted LLM error: {detail}"
+
+
+async def _draft_via_agent(
+    *,
+    conv: Conversation,
+    system: str,
+    user_msg: str,
+) -> str:
+    """Run the rentmate chat agent for the mirror conversation.
+
+    Wraps the call in ``start_run(source="extension", conversation_id=...)``
+    so DevTools surfaces the run alongside chat/task agent runs. The agent
+    is invoked with a single-turn user prompt containing the formatted
+    transcript — we don't replay individual messages as alternating
+    user/assistant turns because TenantCloud's PM/tenant labels don't
+    cleanly map onto the agent's role taxonomy.
+    """
+    from llm import registry as agent_registry_mod
+    from llm.client import call_agent
+    from llm.runs import derive_run_metadata, start_run
+
+    agent_id = agent_registry_mod.agent_registry.ensure_agent(resolve_account_id(), None)
+    run_metadata = derive_run_metadata(
+        source_override="extension",
+        conversation_id=str(conv.external_id),
+    )
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user_msg},
+    ]
+    with start_run(**run_metadata, trigger_input=user_msg) as run:
+        agent_resp = await call_agent(
+            agent_id,
+            session_key=f"extension:{conv.external_id}",
+            messages=messages,
+            trace_context={"conversation_id": str(conv.external_id)},
+        )
+        suggestion = (getattr(agent_resp, "reply", "") or "").strip()
+        if suggestion:
+            run.complete(status="completed", final_response=suggestion[:500])
+    return suggestion
+
+
+async def _one_shot_completion(*, system: str, user_msg: str) -> str:
+    """Fallback completion for callers without an external_thread_id.
+
+    Older versions of the chrome extension don't send a thread id; rather
+    than refuse those requests we still draft a reply via a single
+    LiteLLM call (no AgentRun, no mirror). Once every PM has updated the
+    extension this branch can go away.
+    """
+    import litellm
+
+    from llm.model_config import build_litellm_request_kwargs
+
+    model = os.getenv("LLM_MODEL", "openai/gpt-4o-mini")
+    kwargs = build_litellm_request_kwargs(
+        model=model,
+        api_base=os.getenv("LLM_BASE_URL") or None,
+        api_key=os.getenv("LLM_API_KEY"),
+        app_name="rentmate-chrome-extension",
+    )
+    resp = await litellm.acompletion(
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": user_msg},
+        ],
+        max_tokens=200,
+        temperature=0.4,
+        **kwargs,
+    )
+    return (resp.choices[0].message.content or "").strip()
 
 
 async def draft_reply(
@@ -188,15 +450,20 @@ async def draft_reply(
     header_description: str | None,
     tenant_id: str | None,
     property_id: str | None,
+    external_thread_id: str | None = None,
 ) -> dict[str, Any]:
-    """Run a single LiteLLM completion and return the drafted reply +
-    matched-tenant echo. On any LLM error, populate ``error`` and
-    ``fallback`` so the chrome extension can surface a real banner
-    instead of pretending the canned reply is a draft."""
-    import litellm
+    """Draft a TenantCloud reply, persist a read-only mirror, return the draft.
 
-    from llm.model_config import build_litellm_request_kwargs
+    When ``external_thread_id`` is provided we upsert a
+    ``TENANTCLOUD_MIRROR`` Conversation, dedup-insert any new turns from
+    ``conversation_history``, and run the actual rentmate agent so the
+    invocation appears in DevTools. Without an external thread id we fall
+    back to a one-shot LiteLLM completion (older extension versions).
 
+    On any failure the result still contains a canned ``suggestion`` plus
+    ``error`` + ``fallback=True`` so the extension banner can surface the
+    real cause instead of pretending the canned reply is a draft.
+    """
     matched_tenant = _resolve_tenant_for_reply(db, tenant_id)
     system = _build_system_prompt(
         tenant_payload=matched_tenant,
@@ -205,34 +472,36 @@ async def draft_reply(
     )
     user_msg = _build_user_message(conversation_history or [])
 
-    model = os.getenv("LLM_MODEL", "openai/gpt-4o-mini")
-    kwargs = build_litellm_request_kwargs(
-        model=model,
-        api_base=os.getenv("LLM_BASE_URL") or None,
-        api_key=os.getenv("LLM_API_KEY"),
-        app_name="rentmate-chrome-extension",
-    )
-    try:
-        resp = await litellm.acompletion(
-            messages=[
-                {"role": "system", "content": system},
-                {"role": "user", "content": user_msg},
-            ],
-            max_tokens=200,
-            temperature=0.4,
-            **kwargs,
+    mirror_conv: Conversation | None = None
+    if external_thread_id:
+        mirror_conv = _upsert_mirror_conversation(
+            db,
+            external_thread_id=external_thread_id,
+            header_title=header_title,
+            header_description=header_description,
+            tenant_payload=matched_tenant,
+            property_id=property_id,
         )
-        suggestion = (resp.choices[0].message.content or "").strip()
+        _sync_mirror_messages(db, conv=mirror_conv, conversation_history=conversation_history or [])
+        db.commit()
+        db.refresh(mirror_conv)
+
+    try:
+        if mirror_conv is not None:
+            suggestion = await _draft_via_agent(conv=mirror_conv, system=system, user_msg=user_msg)
+        else:
+            suggestion = await _one_shot_completion(system=system, user_msg=user_msg)
         if not suggestion:
             raise ValueError("empty completion")
         suggestion = suggestion[:500]
     except Exception as exc:  # noqa: BLE001
-        logger.warning("[extension] suggestReply LLM failed; using canned: %s", exc)
+        logger.warning("[extension] suggestReply agent/LLM failed; using canned: %s", exc)
         return {
             "suggestion": _FALLBACK_REPLY,
             "matched_tenant": matched_tenant,
             "error": _classify_llm_error(exc),
             "fallback": True,
+            "conversation_external_id": str(mirror_conv.external_id) if mirror_conv else None,
         }
 
     return {
@@ -240,4 +509,5 @@ async def draft_reply(
         "matched_tenant": matched_tenant,
         "error": None,
         "fallback": False,
+        "conversation_external_id": str(mirror_conv.external_id) if mirror_conv else None,
     }

--- a/gql/services/extension_service.py
+++ b/gql/services/extension_service.py
@@ -7,7 +7,7 @@ Three responsibilities:
   rentmate tenant id before drafting a reply.
 - ``draft_reply`` — drive the actual rentmate agent over a TenantCloud
   conversation and return its drafted reply. The thread is mirrored into
-  rentmate as a read-only ``TENANTCLOUD_MIRROR`` Conversation so DevTools
+  rentmate as a read-only ``MIRRORED_CHAT`` Conversation so DevTools
   can show the AgentRun, and so re-clicking "Suggest" for the same thread
   doesn't duplicate the mirrored history.
 - ``MirrorConversationReadOnly`` — exception raised when something tries to
@@ -55,7 +55,7 @@ _PM_SENDER_TOKENS = ("you", "property manager", "manager")
 
 
 class MirrorConversationReadOnly(Exception):
-    """Raised when send-message paths target a TENANTCLOUD_MIRROR Conversation.
+    """Raised when send-message paths target a MIRRORED_CHAT Conversation.
 
     The inbound TenantCloud thread is the authoritative source for both
     PM and tenant turns; new replies happen in TenantCloud, not rentmate.
@@ -163,7 +163,7 @@ def _find_mirror_conversation(db: Session, *, external_thread_id: str) -> Conver
         .filter_by(
             org_id=resolve_org_id(),
             creator_id=resolve_account_id(),
-            conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+            conversation_type=ConversationType.MIRRORED_CHAT,
         )
         .all()
     )
@@ -207,7 +207,7 @@ def _upsert_mirror_conversation(
             creator_id=resolve_account_id(),
             subject=subject[:255],
             property_id=property_id or (tenant_payload or {}).get("property_id"),
-            conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+            conversation_type=ConversationType.MIRRORED_CHAT,
             is_group=False,
             is_archived=False,
             extra=extra,
@@ -489,7 +489,7 @@ async def draft_reply(
     Otherwise behaves as the standard *Suggest* flow.
 
     When ``external_thread_id`` is provided we upsert a
-    ``TENANTCLOUD_MIRROR`` Conversation, dedup-insert any new turns from
+    ``MIRRORED_CHAT`` Conversation, dedup-insert any new turns from
     ``conversation_history``, and run the actual rentmate agent so the
     invocation appears in DevTools. Without an external thread id we fall
     back to a one-shot LiteLLM completion (older extension versions).

--- a/gql/services/extension_service.py
+++ b/gql/services/extension_service.py
@@ -310,15 +310,28 @@ def _build_system_prompt(
     tenant_payload: dict[str, Any] | None,
     header_title: str | None,
     header_description: str | None,
+    refine_mode: bool = False,
 ) -> str:
-    intro = (
-        "You are RentMate drafting a reply on behalf of the property "
-        "manager. The PM is composing a response to a tenant inside "
-        "TenantCloud. Draft a single SMS-style reply, 1-3 sentences, "
-        "warm and professional. Do not invent facts or commit to dates. "
-        "Do not mention RentMate or that you are an AI. Output only the "
-        "reply text, no labels."
-    )
+    if refine_mode:
+        intro = (
+            "You are RentMate refining a draft reply the property manager "
+            "has already typed in TenantCloud. Polish the draft for "
+            "clarity, tone, and completeness while preserving the PM's "
+            "intent and any concrete facts they wrote (dates, vendor "
+            "names, dollar amounts). Keep it SMS-style, 1-3 sentences, "
+            "warm and professional. Do not invent facts the PM didn't "
+            "include. Do not mention RentMate or that you are an AI. "
+            "Output only the refined reply text, no labels or commentary."
+        )
+    else:
+        intro = (
+            "You are RentMate drafting a reply on behalf of the property "
+            "manager. The PM is composing a response to a tenant inside "
+            "TenantCloud. Draft a single SMS-style reply, 1-3 sentences, "
+            "warm and professional. Do not invent facts or commit to "
+            "dates. Do not mention RentMate or that you are an AI. "
+            "Output only the reply text, no labels."
+        )
     parts: list[str] = [intro]
     if tenant_payload:
         unit = f" ({tenant_payload['unit_label']})" if tenant_payload.get("unit_label") else ""
@@ -333,14 +346,29 @@ def _build_system_prompt(
     return "\n".join(parts)
 
 
-def _build_user_message(history: list[dict[str, str]]) -> str:
-    if not history:
-        return "(No prior messages.) Open the conversation with a brief acknowledgement."
-    transcript = "\n".join(
+def _build_user_message(
+    history: list[dict[str, str]],
+    *,
+    draft_text: str | None = None,
+) -> str:
+    transcript_lines = [
         f"{(turn.get('sender') or 'Tenant')}: {(turn.get('text') or '').strip()}"
         for turn in history
         if (turn.get('text') or '').strip()
-    )
+    ]
+    transcript = "\n".join(transcript_lines) if transcript_lines else "(No prior messages.)"
+    if draft_text:
+        return (
+            "Recent conversation between the property manager and the "
+            "tenant (most recent last):\n\n"
+            f"{transcript}\n\n"
+            "The property manager has typed the following draft reply. "
+            "Refine it — keep their intent and any concrete facts, but "
+            "improve clarity and tone:\n\n"
+            f"{draft_text.strip()}"
+        )
+    if not transcript_lines:
+        return "(No prior messages.) Open the conversation with a brief acknowledgement."
     return (
         "Recent conversation between the property manager and the tenant "
         "(most recent last):\n\n"
@@ -451,8 +479,14 @@ async def draft_reply(
     tenant_id: str | None,
     property_id: str | None,
     external_thread_id: str | None = None,
+    draft_text: str | None = None,
 ) -> dict[str, Any]:
-    """Draft a TenantCloud reply, persist a read-only mirror, return the draft.
+    """Draft (or refine) a TenantCloud reply and persist a read-only mirror.
+
+    When ``draft_text`` is non-empty the extension is in *Refine* mode —
+    the PM has already typed something into TenantCloud's reply box, so
+    we ask the agent to polish that draft instead of composing fresh.
+    Otherwise behaves as the standard *Suggest* flow.
 
     When ``external_thread_id`` is provided we upsert a
     ``TENANTCLOUD_MIRROR`` Conversation, dedup-insert any new turns from
@@ -464,13 +498,18 @@ async def draft_reply(
     ``error`` + ``fallback=True`` so the extension banner can surface the
     real cause instead of pretending the canned reply is a draft.
     """
+    refine_mode = bool((draft_text or "").strip())
     matched_tenant = _resolve_tenant_for_reply(db, tenant_id)
     system = _build_system_prompt(
         tenant_payload=matched_tenant,
         header_title=header_title,
         header_description=header_description,
+        refine_mode=refine_mode,
     )
-    user_msg = _build_user_message(conversation_history or [])
+    user_msg = _build_user_message(
+        conversation_history or [],
+        draft_text=draft_text if refine_mode else None,
+    )
 
     mirror_conv: Conversation | None = None
     if external_thread_id:

--- a/gql/services/extension_service.py
+++ b/gql/services/extension_service.py
@@ -3,16 +3,16 @@
 Three responsibilities:
 
 - ``rank_tenants`` — fuzzy-search the org's active tenants by name, email,
-  or phone. Used by the extension to map a TenantCloud sender name onto a
-  rentmate tenant id before drafting a reply.
-- ``draft_reply`` — drive the actual rentmate agent over a TenantCloud
-  conversation and return its drafted reply. The thread is mirrored into
+  or phone. Used by the extension to map a scraped sender name from an
+  external chat platform onto a rentmate tenant id before drafting.
+- ``draft_reply`` — drive the actual rentmate agent over an external chat
+  thread and return its drafted reply. The thread is mirrored into
   rentmate as a read-only ``MIRRORED_CHAT`` Conversation so DevTools
   can show the AgentRun, and so re-clicking "Suggest" for the same thread
   doesn't duplicate the mirrored history.
-- ``MirrorConversationReadOnly`` — exception raised when something tries to
-  send a new message into a mirror conversation; the inbound history is
-  authoritative, replies happen back in TenantCloud.
+- ``MirrorConversationReadOnly`` — exception raised when something tries
+  to send a new message into a mirror conversation; the inbound history
+  is authoritative, replies happen back on the source platform.
 
 Both helpers run inside a request context that already has org/account
 ids resolved (subdomain middleware / JWT auth), so they don't take ids
@@ -48,17 +48,24 @@ _FULL_NAME_MATCH_SCORE = 50
 _PARTIAL_NAME_MATCH_SCORE = 25
 _MAX_RESULTS = 3
 
-# Lowercase tokens TenantCloud uses for the property manager themselves.
-# Used to map a scraped sender name onto ParticipantType.ACCOUNT_USER vs
-# EXTERNAL_CONTACT when mirroring messages.
+# Lowercase tokens external chat platforms use for the property manager
+# themselves. Used to map a scraped sender name onto
+# ParticipantType.ACCOUNT_USER vs EXTERNAL_CONTACT when mirroring
+# messages — most platforms label the PM as "You" or "Property Manager".
 _PM_SENDER_TOKENS = ("you", "property manager", "manager")
+
+# Source identifier used when the client doesn't supply one. Stored on
+# the mirror Conversation's ``extra.source`` so future analytics /
+# integrations can tell where a thread came from. The chrome extension
+# overrides this with its own platform-specific value.
+_DEFAULT_SOURCE = "chrome_extension"
 
 
 class MirrorConversationReadOnly(Exception):
     """Raised when send-message paths target a MIRRORED_CHAT Conversation.
 
-    The inbound TenantCloud thread is the authoritative source for both
-    PM and tenant turns; new replies happen in TenantCloud, not rentmate.
+    The inbound mirror thread is the authoritative record for both PM and
+    tenant turns; new replies happen on the source platform, not rentmate.
     """
 
 
@@ -152,11 +159,11 @@ def _is_pm_sender(sender: str | None) -> bool:
 
 
 def _find_mirror_conversation(db: Session, *, external_thread_id: str) -> Conversation | None:
-    """Look up the read-only TenantCloud mirror for this thread, if any.
+    """Look up the read-only mirror Conversation for this external thread.
 
     Stored in ``Conversation.extra->>'external_thread_id'`` so two threads
-    with the same TenantCloud URL don't collide and so we can dedup
-    messages on a re-import without scanning every conversation in the org.
+    with the same external URL don't collide and so we can dedup messages
+    on a re-import without scanning every conversation in the org.
     """
     rows = (
         db.query(Conversation)
@@ -182,19 +189,22 @@ def _upsert_mirror_conversation(
     header_description: str | None,
     tenant_payload: dict[str, Any] | None,
     property_id: str | None,
+    source: str | None = None,
 ) -> Conversation:
-    """Find or create the read-only mirror Conversation for a TenantCloud thread.
+    """Find or create the read-only mirror Conversation for an external thread.
 
     The conversation is keyed by ``external_thread_id`` (typically the
-    scraped TenantCloud URL pathname) so re-clicking ``Suggest`` for the
-    same thread reuses the existing row instead of spawning duplicates.
+    URL pathname scraped from the source platform) so re-clicking
+    ``Suggest`` for the same thread reuses the existing row instead of
+    spawning duplicates.
     """
     conv = _find_mirror_conversation(db, external_thread_id=external_thread_id)
     now = datetime.now(UTC)
-    subject = (header_title or "").strip() or "TenantCloud thread"
+    subject = (header_title or "").strip() or "Mirrored thread"
+    resolved_source = (source or _DEFAULT_SOURCE).strip() or _DEFAULT_SOURCE
     if conv is None:
         extra = {
-            "source": "tenantcloud",
+            "source": resolved_source,
             "external_thread_id": str(external_thread_id),
             "read_only": True,
         }
@@ -237,16 +247,16 @@ def _upsert_mirror_conversation(
 
 
 def _existing_mirror_indices(conv: Conversation) -> set[int]:
-    """Indices of TenantCloud turns already mirrored on this conversation.
+    """Indices of external turns already mirrored on this conversation.
 
     Each mirrored Message stores its zero-based position inside the
-    TenantCloud thread under ``meta.tenantcloud_index``. The set is used
-    to skip turns that were imported on a previous ``Suggest`` click.
+    source thread under ``meta.mirror_index``. The set is used to skip
+    turns that were imported on a previous ``Suggest`` click.
     """
     indices: set[int] = set()
     for msg in conv.messages or []:
         meta = msg.meta or {}
-        idx = meta.get("tenantcloud_index")
+        idx = meta.get("mirror_index")
         if isinstance(idx, int):
             indices.add(idx)
     return indices
@@ -257,12 +267,13 @@ def _sync_mirror_messages(
     *,
     conv: Conversation,
     conversation_history: list[dict[str, str]],
+    source: str | None = None,
 ) -> int:
-    """Insert any TenantCloud turns we haven't mirrored yet.
+    """Insert any external turns we haven't mirrored yet.
 
-    Dedup is position-based: TenantCloud always renders a thread
+    Dedup is position-based: external chat platforms render a thread
     chronologically, so the n-th turn is stable across scrapes. Each
-    mirrored Message records ``meta.tenantcloud_index = n``; turns whose
+    mirrored Message records ``meta.mirror_index = n``; turns whose
     index is already on the conversation are skipped. Returns the number
     of messages newly inserted.
     """
@@ -292,8 +303,8 @@ def _sync_mirror_messages(
             is_ai=False,
             is_system=False,
             meta={
-                "source": "tenantcloud",
-                "tenantcloud_index": idx,
+                "source": (source or _DEFAULT_SOURCE),
+                "mirror_index": idx,
                 "direction": "outbound" if is_pm else "inbound",
             },
             sent_at=now,
@@ -315,22 +326,23 @@ def _build_system_prompt(
     if refine_mode:
         intro = (
             "You are RentMate refining a draft reply the property manager "
-            "has already typed in TenantCloud. Polish the draft for "
-            "clarity, tone, and completeness while preserving the PM's "
-            "intent and any concrete facts they wrote (dates, vendor "
-            "names, dollar amounts). Keep it SMS-style, 1-3 sentences, "
-            "warm and professional. Do not invent facts the PM didn't "
-            "include. Do not mention RentMate or that you are an AI. "
-            "Output only the refined reply text, no labels or commentary."
+            "has already typed in their tenant chat tool. Polish the "
+            "draft for clarity, tone, and completeness while preserving "
+            "the PM's intent and any concrete facts they wrote (dates, "
+            "vendor names, dollar amounts). Keep it SMS-style, 1-3 "
+            "sentences, warm and professional. Do not invent facts the "
+            "PM didn't include. Do not mention RentMate or that you are "
+            "an AI. Output only the refined reply text, no labels or "
+            "commentary."
         )
     else:
         intro = (
             "You are RentMate drafting a reply on behalf of the property "
-            "manager. The PM is composing a response to a tenant inside "
-            "TenantCloud. Draft a single SMS-style reply, 1-3 sentences, "
-            "warm and professional. Do not invent facts or commit to "
-            "dates. Do not mention RentMate or that you are an AI. "
-            "Output only the reply text, no labels."
+            "manager. The PM is composing a response to a tenant in their "
+            "tenant chat tool. Draft a single SMS-style reply, 1-3 "
+            "sentences, warm and professional. Do not invent facts or "
+            "commit to dates. Do not mention RentMate or that you are an "
+            "AI. Output only the reply text, no labels."
         )
     parts: list[str] = [intro]
     if tenant_payload:
@@ -410,7 +422,7 @@ async def _draft_via_agent(
     so DevTools surfaces the run alongside chat/task agent runs. The agent
     is invoked with a single-turn user prompt containing the formatted
     transcript — we don't replay individual messages as alternating
-    user/assistant turns because TenantCloud's PM/tenant labels don't
+    user/assistant turns because external chat platforms' PM/tenant labels don't
     cleanly map onto the agent's role taxonomy.
     """
     from llm import registry as agent_registry_mod
@@ -480,13 +492,15 @@ async def draft_reply(
     property_id: str | None,
     external_thread_id: str | None = None,
     draft_text: str | None = None,
+    source: str | None = None,
 ) -> dict[str, Any]:
-    """Draft (or refine) a TenantCloud reply and persist a read-only mirror.
+    """Draft (or refine) a reply for an external chat thread and persist
+    a read-only mirror.
 
     When ``draft_text`` is non-empty the extension is in *Refine* mode —
-    the PM has already typed something into TenantCloud's reply box, so
-    we ask the agent to polish that draft instead of composing fresh.
-    Otherwise behaves as the standard *Suggest* flow.
+    the PM has already typed something into the source platform's reply
+    box, so we ask the agent to polish that draft instead of composing
+    fresh. Otherwise behaves as the standard *Suggest* flow.
 
     When ``external_thread_id`` is provided we upsert a
     ``MIRRORED_CHAT`` Conversation, dedup-insert any new turns from
@@ -520,8 +534,14 @@ async def draft_reply(
             header_description=header_description,
             tenant_payload=matched_tenant,
             property_id=property_id,
+            source=source,
         )
-        _sync_mirror_messages(db, conv=mirror_conv, conversation_history=conversation_history or [])
+        _sync_mirror_messages(
+            db,
+            conv=mirror_conv,
+            conversation_history=conversation_history or [],
+            source=source,
+        )
         db.commit()
         db.refresh(mirror_conv)
 

--- a/gql/services/tests/test_chat_service.py
+++ b/gql/services/tests/test_chat_service.py
@@ -148,7 +148,7 @@ def test_build_agent_message_history_labels_task_ai_conversation_as_internal_pm_
     history = chat_service.build_agent_message_history(
         db,
         conv_id=convo.id,
-        user_message="The payment URL should be available in TenantCloud.",
+        user_message="The payment URL should be available in the tenant portal.",
         context="task context",
     )
 
@@ -191,7 +191,7 @@ def test_build_agent_message_history_labels_tenant_conversation_as_tenant_facing
     history = chat_service.build_agent_message_history(
         db,
         conv_id=convo.id,
-        user_message="Can I pay through TenantCloud?",
+        user_message="Can I pay through the tenant portal?",
         context="task context",
     )
 

--- a/gql/services/tests/test_extension_service.py
+++ b/gql/services/tests/test_extension_service.py
@@ -486,6 +486,63 @@ def test_send_message_blocks_for_mirror_conversation(db):
             chat_service.send_message(db, conversation_id=conv.id, body="nope")
 
 
+def test_draft_reply_refine_mode_includes_user_draft_in_prompt(db):
+    """When the PM has typed text into TenantCloud's reply box the
+    extension sends ``draft_text`` and rentmate flips into Refine mode:
+    the system prompt asks the agent to polish, and the user prompt
+    quotes the draft verbatim so the agent can preserve PM intent."""
+    with _request_scope():
+        captured: dict = {}
+
+        async def fake_call_agent(_agent_id, *, session_key, messages, trace_context=None, **_kwargs):
+            captured["system"] = messages[0]["content"]
+            captured["user"] = messages[1]["content"]
+            return AgentResponse(reply="Refined: hi Marcus, plumber tomorrow at 10.", side_effects=[])
+
+        with patch("llm.client.call_agent", side_effect=fake_call_agent):
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[
+                    {"sender": "Marcus", "text": "Dishwasher leaked again."},
+                ],
+                header_title="Dishwasher leak",
+                header_description=None,
+                tenant_id=None, property_id=None,
+                external_thread_id="tenantcloud:/messenger/conversation/9100",
+                draft_text="hey marcus plumber will come tomorrow at 10",
+            ))
+
+    assert result["fallback"] is False
+    assert "refining a draft" in captured["system"].lower()
+    assert "preserving the PM's intent" in captured["system"]
+    assert "hey marcus plumber will come tomorrow at 10" in captured["user"]
+    assert result["suggestion"].startswith("Refined:")
+
+
+def test_draft_reply_blank_draft_text_uses_compose_mode(db):
+    """A whitespace-only ``draft_text`` shouldn't trigger Refine mode —
+    the PM hasn't actually typed anything meaningful, so we compose fresh."""
+    with _request_scope():
+        captured: dict = {}
+
+        async def fake_call_agent(_agent_id, *, session_key, messages, trace_context=None, **_kwargs):
+            captured["system"] = messages[0]["content"]
+            return AgentResponse(reply="Hi.", side_effects=[])
+
+        with patch("llm.client.call_agent", side_effect=fake_call_agent):
+            asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "T", "text": "hi"}],
+                header_title=None, header_description=None,
+                tenant_id=None, property_id=None,
+                external_thread_id="tenantcloud:/messenger/conversation/9101",
+                draft_text="   \n  ",
+            ))
+
+    assert "drafting a reply" in captured["system"].lower()
+    assert "refining a draft" not in captured["system"].lower()
+
+
 def test_send_autonomous_message_blocks_for_mirror_conversation(db):
     """The agent's autonomous-message path is also blocked so a buggy
     agent run can't accidentally post into the read-only mirror."""

--- a/gql/services/tests/test_extension_service.py
+++ b/gql/services/tests/test_extension_service.py
@@ -11,12 +11,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backends.local_auth import reset_request_context, set_request_context
-from db.models import Lease, Property, Tenant, Unit, User
+from db.models import (
+    AgentRun,
+    Conversation,
+    ConversationType,
+    Lease,
+    Message,
+    ParticipantType,
+    Property,
+    Tenant,
+    Unit,
+    User,
+)
 from gql.services.extension_service import (
     _FALLBACK_REPLY,
+    MirrorConversationReadOnly,
     draft_reply,
     rank_tenants,
 )
+from llm.client import AgentResponse
 
 
 @contextmanager
@@ -261,3 +274,237 @@ def test_draft_reply_unknown_tenant_id_returns_no_match(db):
             ))
 
     assert result["matched_tenant"] is None
+
+
+# ─── TenantCloud mirror + agent routing ─────────────────────────────────
+
+
+def _patch_call_agent(reply: str):
+    """Mock the agent so ``draft_reply`` returns deterministic text without
+    spinning up the real LLM. Mirrors how the chat-stream tests stub
+    ``llm.client.call_agent`` in ``tests/test_chat_integration.py``."""
+    async def fake_call_agent(_agent_id, *, session_key, messages, trace_context=None, **_kwargs):
+        fake_call_agent.last_call = {
+            "session_key": session_key,
+            "messages": messages,
+            "trace_context": trace_context,
+        }
+        return AgentResponse(reply=reply, side_effects=[])
+    fake_call_agent.last_call = None
+    return patch("llm.client.call_agent", side_effect=fake_call_agent), fake_call_agent
+
+
+def test_draft_reply_with_thread_id_creates_mirror_conversation(db):
+    """First Suggest click for a thread creates a TENANTCLOUD_MIRROR conversation
+    keyed by ``external_thread_id`` and dedup-mirrors the scraped history."""
+    with _request_scope():
+        tenant = _seed_tenant(
+            db, first="Marcus", last="Johnson", email="marcus@example.com",
+            with_lease=True,
+        )
+        ctx, _spy = _patch_call_agent("Hi Marcus — booking a plumber for tomorrow.")
+        with ctx:
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[
+                    {"sender": "Marcus", "text": "The dishwasher is leaking."},
+                    {"sender": "You", "text": "Got it, I'll send someone over."},
+                    {"sender": "Marcus", "text": "Thanks!"},
+                ],
+                header_title="Dishwasher leak",
+                header_description="Standing water under the unit.",
+                tenant_id=str(tenant.external_id),
+                property_id=None,
+                external_thread_id="tenantcloud:/messenger/conversation/9001",
+            ))
+
+    assert result["fallback"] is False
+    assert result["conversation_external_id"] is not None
+
+    conv = db.query(Conversation).filter_by(
+        external_id=result["conversation_external_id"],
+    ).one()
+    assert conv.conversation_type == ConversationType.TENANTCLOUD_MIRROR
+    assert (conv.extra or {}).get("source") == "tenantcloud"
+    assert (conv.extra or {}).get("read_only") is True
+    assert (conv.extra or {}).get("external_thread_id") == "tenantcloud:/messenger/conversation/9001"
+    assert conv.subject == "Dishwasher leak"
+
+    msgs = sorted(
+        db.query(Message).filter_by(conversation_id=conv.id).all(),
+        key=lambda m: (m.meta or {}).get("tenantcloud_index", -1),
+    )
+    assert [m.body for m in msgs] == [
+        "The dishwasher is leaking.",
+        "Got it, I'll send someone over.",
+        "Thanks!",
+    ]
+    # Sender mapping: PM tokens ("You") map to ACCOUNT_USER, others to
+    # EXTERNAL_CONTACT — matters because the read-only guard and any
+    # downstream UI styling key off sender_type.
+    types = [m.sender_type for m in msgs]
+    assert types == [
+        ParticipantType.EXTERNAL_CONTACT,
+        ParticipantType.ACCOUNT_USER,
+        ParticipantType.EXTERNAL_CONTACT,
+    ]
+
+
+def test_draft_reply_repeat_call_dedups_existing_messages(db):
+    """Re-clicking Suggest after the tenant sent another message only inserts
+    the new turn — the first three are already mirrored."""
+    with _request_scope():
+        ctx, _spy = _patch_call_agent("OK.")
+        history = [
+            {"sender": "Marcus", "text": "The dishwasher is leaking."},
+            {"sender": "You", "text": "Got it, I'll send someone over."},
+            {"sender": "Marcus", "text": "Thanks!"},
+        ]
+        with ctx:
+            asyncio.run(draft_reply(
+                db,
+                conversation_history=history,
+                header_title="Dishwasher leak",
+                header_description=None,
+                tenant_id=None, property_id=None,
+                external_thread_id="tenantcloud:/messenger/conversation/9002",
+            ))
+            # Second click: same thread, one extra tenant turn appended.
+            asyncio.run(draft_reply(
+                db,
+                conversation_history=[
+                    *history,
+                    {"sender": "Marcus", "text": "Plumber just left, all good."},
+                ],
+                header_title="Dishwasher leak",
+                header_description=None,
+                tenant_id=None, property_id=None,
+                external_thread_id="tenantcloud:/messenger/conversation/9002",
+            ))
+
+    convs = db.query(Conversation).filter_by(
+        conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+    ).all()
+    assert len(convs) == 1
+    msgs = db.query(Message).filter_by(conversation_id=convs[0].id).all()
+    bodies = sorted(m.body for m in msgs)
+    assert bodies == [
+        "Got it, I'll send someone over.",
+        "Plumber just left, all good.",
+        "Thanks!",
+        "The dishwasher is leaking.",
+    ]
+
+
+def test_draft_reply_records_agent_run_against_mirror(db):
+    """Routing through ``call_agent`` writes an ``AgentRun`` row whose
+    ``conversation_id`` is the mirror's external_id, so DevTools groups
+    extension drafts alongside chat/task agent runs."""
+    with _request_scope():
+        ctx, _spy = _patch_call_agent("Replied.")
+        with ctx:
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "T", "text": "hi"}],
+                header_title=None, header_description=None,
+                tenant_id=None, property_id=None,
+                external_thread_id="tenantcloud:/messenger/conversation/9003",
+            ))
+
+    convo_uid = result["conversation_external_id"]
+    assert convo_uid is not None
+    runs = db.query(AgentRun).filter_by(conversation_id=convo_uid).all()
+    assert len(runs) == 1
+    assert runs[0].source == "extension"
+    assert runs[0].status == "completed"
+
+
+def test_draft_reply_session_key_uses_mirror_external_id(db):
+    """``session_key`` carries the mirror's external_id so downstream
+    agent state (memory, tracing) is partitioned per TenantCloud thread
+    instead of leaking into the PM's normal chat history."""
+    with _request_scope():
+        ctx, spy = _patch_call_agent("OK.")
+        with ctx:
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "T", "text": "hi"}],
+                header_title=None, header_description=None,
+                tenant_id=None, property_id=None,
+                external_thread_id="tenantcloud:/messenger/conversation/9004",
+            ))
+
+    assert spy.last_call is not None
+    assert spy.last_call["session_key"] == f"extension:{result['conversation_external_id']}"
+    assert spy.last_call["trace_context"]["conversation_id"] == result["conversation_external_id"]
+
+
+def test_draft_reply_without_thread_id_falls_back_to_one_shot(db):
+    """Older extension versions don't send ``external_thread_id``. Those
+    requests still get a draft (one-shot LiteLLM) but produce no mirror
+    conversation and no AgentRun — preserving v1 behavior during rollout."""
+    with _request_scope():
+        async def fake_acompletion(*_args, **_kwargs):
+            return _fake_completion("Legacy reply.")
+        with patch("litellm.acompletion", side_effect=fake_acompletion):
+            result = asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "T", "text": "hi"}],
+                header_title=None, header_description=None,
+                tenant_id=None, property_id=None,
+                external_thread_id=None,
+            ))
+
+    assert result["suggestion"] == "Legacy reply."
+    assert result["conversation_external_id"] is None
+    assert db.query(Conversation).filter_by(
+        conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+    ).count() == 0
+
+
+def test_send_message_blocks_for_mirror_conversation(db):
+    """``chat_service.send_message`` refuses to write into a TenantCloud
+    mirror — replies must go through TenantCloud, not rentmate."""
+    from gql.services import chat_service
+
+    with _request_scope():
+        ctx, _spy = _patch_call_agent("OK.")
+        with ctx:
+            asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "T", "text": "hi"}],
+                header_title=None, header_description=None,
+                tenant_id=None, property_id=None,
+                external_thread_id="tenantcloud:/messenger/conversation/9005",
+            ))
+
+        conv = db.query(Conversation).filter_by(
+            conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+        ).one()
+
+        with pytest.raises(MirrorConversationReadOnly):
+            chat_service.send_message(db, conversation_id=conv.id, body="nope")
+
+
+def test_send_autonomous_message_blocks_for_mirror_conversation(db):
+    """The agent's autonomous-message path is also blocked so a buggy
+    agent run can't accidentally post into the read-only mirror."""
+    from gql.services import chat_service
+
+    with _request_scope():
+        ctx, _spy = _patch_call_agent("OK.")
+        with ctx:
+            asyncio.run(draft_reply(
+                db,
+                conversation_history=[{"sender": "T", "text": "hi"}],
+                header_title=None, header_description=None,
+                tenant_id=None, property_id=None,
+                external_thread_id="tenantcloud:/messenger/conversation/9006",
+            ))
+
+        conv = db.query(Conversation).filter_by(
+            conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+        ).one()
+
+        with pytest.raises(MirrorConversationReadOnly):
+            chat_service.send_autonomous_message(db, conversation_id=conv.id, body="nope")

--- a/gql/services/tests/test_extension_service.py
+++ b/gql/services/tests/test_extension_service.py
@@ -295,7 +295,7 @@ def _patch_call_agent(reply: str):
 
 
 def test_draft_reply_with_thread_id_creates_mirror_conversation(db):
-    """First Suggest click for a thread creates a TENANTCLOUD_MIRROR conversation
+    """First Suggest click for a thread creates a MIRRORED_CHAT conversation
     keyed by ``external_thread_id`` and dedup-mirrors the scraped history."""
     with _request_scope():
         tenant = _seed_tenant(
@@ -324,7 +324,7 @@ def test_draft_reply_with_thread_id_creates_mirror_conversation(db):
     conv = db.query(Conversation).filter_by(
         external_id=result["conversation_external_id"],
     ).one()
-    assert conv.conversation_type == ConversationType.TENANTCLOUD_MIRROR
+    assert conv.conversation_type == ConversationType.MIRRORED_CHAT
     assert (conv.extra or {}).get("source") == "tenantcloud"
     assert (conv.extra or {}).get("read_only") is True
     assert (conv.extra or {}).get("external_thread_id") == "tenantcloud:/messenger/conversation/9001"
@@ -383,7 +383,7 @@ def test_draft_reply_repeat_call_dedups_existing_messages(db):
             ))
 
     convs = db.query(Conversation).filter_by(
-        conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+        conversation_type=ConversationType.MIRRORED_CHAT,
     ).all()
     assert len(convs) == 1
     msgs = db.query(Message).filter_by(conversation_id=convs[0].id).all()
@@ -458,7 +458,7 @@ def test_draft_reply_without_thread_id_falls_back_to_one_shot(db):
     assert result["suggestion"] == "Legacy reply."
     assert result["conversation_external_id"] is None
     assert db.query(Conversation).filter_by(
-        conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+        conversation_type=ConversationType.MIRRORED_CHAT,
     ).count() == 0
 
 
@@ -479,7 +479,7 @@ def test_send_message_blocks_for_mirror_conversation(db):
             ))
 
         conv = db.query(Conversation).filter_by(
-            conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+            conversation_type=ConversationType.MIRRORED_CHAT,
         ).one()
 
         with pytest.raises(MirrorConversationReadOnly):
@@ -560,7 +560,7 @@ def test_send_autonomous_message_blocks_for_mirror_conversation(db):
             ))
 
         conv = db.query(Conversation).filter_by(
-            conversation_type=ConversationType.TENANTCLOUD_MIRROR,
+            conversation_type=ConversationType.MIRRORED_CHAT,
         ).one()
 
         with pytest.raises(MirrorConversationReadOnly):

--- a/gql/services/tests/test_extension_service.py
+++ b/gql/services/tests/test_extension_service.py
@@ -276,7 +276,7 @@ def test_draft_reply_unknown_tenant_id_returns_no_match(db):
     assert result["matched_tenant"] is None
 
 
-# ─── TenantCloud mirror + agent routing ─────────────────────────────────
+# ─── External-chat mirror + agent routing ──────────────────────────────
 
 
 def _patch_call_agent(reply: str):
@@ -315,7 +315,7 @@ def test_draft_reply_with_thread_id_creates_mirror_conversation(db):
                 header_description="Standing water under the unit.",
                 tenant_id=str(tenant.external_id),
                 property_id=None,
-                external_thread_id="tenantcloud:/messenger/conversation/9001",
+                external_thread_id="ext-thread:9001",
             ))
 
     assert result["fallback"] is False
@@ -325,14 +325,17 @@ def test_draft_reply_with_thread_id_creates_mirror_conversation(db):
         external_id=result["conversation_external_id"],
     ).one()
     assert conv.conversation_type == ConversationType.MIRRORED_CHAT
-    assert (conv.extra or {}).get("source") == "tenantcloud"
+    # Default ``source`` is ``chrome_extension`` when the client
+    # doesn't supply a platform identifier — keeps backend rentmate
+    # source-agnostic. Specific platforms pass their own value.
+    assert (conv.extra or {}).get("source") == "chrome_extension"
     assert (conv.extra or {}).get("read_only") is True
-    assert (conv.extra or {}).get("external_thread_id") == "tenantcloud:/messenger/conversation/9001"
+    assert (conv.extra or {}).get("external_thread_id") == "ext-thread:9001"
     assert conv.subject == "Dishwasher leak"
 
     msgs = sorted(
         db.query(Message).filter_by(conversation_id=conv.id).all(),
-        key=lambda m: (m.meta or {}).get("tenantcloud_index", -1),
+        key=lambda m: (m.meta or {}).get("mirror_index", -1),
     )
     assert [m.body for m in msgs] == [
         "The dishwasher is leaking.",
@@ -367,7 +370,7 @@ def test_draft_reply_repeat_call_dedups_existing_messages(db):
                 header_title="Dishwasher leak",
                 header_description=None,
                 tenant_id=None, property_id=None,
-                external_thread_id="tenantcloud:/messenger/conversation/9002",
+                external_thread_id="ext-thread:9002",
             ))
             # Second click: same thread, one extra tenant turn appended.
             asyncio.run(draft_reply(
@@ -379,7 +382,7 @@ def test_draft_reply_repeat_call_dedups_existing_messages(db):
                 header_title="Dishwasher leak",
                 header_description=None,
                 tenant_id=None, property_id=None,
-                external_thread_id="tenantcloud:/messenger/conversation/9002",
+                external_thread_id="ext-thread:9002",
             ))
 
     convs = db.query(Conversation).filter_by(
@@ -408,7 +411,7 @@ def test_draft_reply_records_agent_run_against_mirror(db):
                 conversation_history=[{"sender": "T", "text": "hi"}],
                 header_title=None, header_description=None,
                 tenant_id=None, property_id=None,
-                external_thread_id="tenantcloud:/messenger/conversation/9003",
+                external_thread_id="ext-thread:9003",
             ))
 
     convo_uid = result["conversation_external_id"]
@@ -421,7 +424,7 @@ def test_draft_reply_records_agent_run_against_mirror(db):
 
 def test_draft_reply_session_key_uses_mirror_external_id(db):
     """``session_key`` carries the mirror's external_id so downstream
-    agent state (memory, tracing) is partitioned per TenantCloud thread
+    agent state (memory, tracing) is partitioned per external thread
     instead of leaking into the PM's normal chat history."""
     with _request_scope():
         ctx, spy = _patch_call_agent("OK.")
@@ -431,7 +434,7 @@ def test_draft_reply_session_key_uses_mirror_external_id(db):
                 conversation_history=[{"sender": "T", "text": "hi"}],
                 header_title=None, header_description=None,
                 tenant_id=None, property_id=None,
-                external_thread_id="tenantcloud:/messenger/conversation/9004",
+                external_thread_id="ext-thread:9004",
             ))
 
     assert spy.last_call is not None
@@ -463,8 +466,8 @@ def test_draft_reply_without_thread_id_falls_back_to_one_shot(db):
 
 
 def test_send_message_blocks_for_mirror_conversation(db):
-    """``chat_service.send_message`` refuses to write into a TenantCloud
-    mirror — replies must go through TenantCloud, not rentmate."""
+    """``chat_service.send_message`` refuses to write into an external-chat
+    mirror — replies must go through the source platform, not rentmate."""
     from gql.services import chat_service
 
     with _request_scope():
@@ -475,7 +478,7 @@ def test_send_message_blocks_for_mirror_conversation(db):
                 conversation_history=[{"sender": "T", "text": "hi"}],
                 header_title=None, header_description=None,
                 tenant_id=None, property_id=None,
-                external_thread_id="tenantcloud:/messenger/conversation/9005",
+                external_thread_id="ext-thread:9005",
             ))
 
         conv = db.query(Conversation).filter_by(
@@ -487,7 +490,7 @@ def test_send_message_blocks_for_mirror_conversation(db):
 
 
 def test_draft_reply_refine_mode_includes_user_draft_in_prompt(db):
-    """When the PM has typed text into TenantCloud's reply box the
+    """When the PM has typed text into the source platform's reply box the
     extension sends ``draft_text`` and rentmate flips into Refine mode:
     the system prompt asks the agent to polish, and the user prompt
     quotes the draft verbatim so the agent can preserve PM intent."""
@@ -508,7 +511,7 @@ def test_draft_reply_refine_mode_includes_user_draft_in_prompt(db):
                 header_title="Dishwasher leak",
                 header_description=None,
                 tenant_id=None, property_id=None,
-                external_thread_id="tenantcloud:/messenger/conversation/9100",
+                external_thread_id="ext-thread:9100",
                 draft_text="hey marcus plumber will come tomorrow at 10",
             ))
 
@@ -535,7 +538,7 @@ def test_draft_reply_blank_draft_text_uses_compose_mode(db):
                 conversation_history=[{"sender": "T", "text": "hi"}],
                 header_title=None, header_description=None,
                 tenant_id=None, property_id=None,
-                external_thread_id="tenantcloud:/messenger/conversation/9101",
+                external_thread_id="ext-thread:9101",
                 draft_text="   \n  ",
             ))
 
@@ -556,7 +559,7 @@ def test_send_autonomous_message_blocks_for_mirror_conversation(db):
                 conversation_history=[{"sender": "T", "text": "hi"}],
                 header_title=None, header_description=None,
                 tenant_id=None, property_id=None,
-                external_thread_id="tenantcloud:/messenger/conversation/9006",
+                external_thread_id="ext-thread:9006",
             ))
 
         conv = db.query(Conversation).filter_by(

--- a/gql/types.py
+++ b/gql/types.py
@@ -1225,6 +1225,11 @@ class SuggestReplyInput:
     # AgentRun is grouped under one row in DevTools and so re-clicking
     # ``Suggest`` for the same thread doesn't duplicate messages.
     external_thread_id: typing.Optional[str] = None
+    # Text the PM has already typed into TenantCloud's reply box. When
+    # set, the extension button reads "Refine" and the agent is asked
+    # to polish the draft (clarity, tone, missing context) instead of
+    # composing a fresh reply.
+    draft_text: typing.Optional[str] = None
 
 
 @strawberry.type

--- a/gql/types.py
+++ b/gql/types.py
@@ -1172,7 +1172,7 @@ class ConversationSummaryType:
 
 
 # ---------------------------------------------------------------------------
-# Chrome extension surface (TenantCloud bridge)
+# Chrome extension surface (external chat platform bridge)
 # ---------------------------------------------------------------------------
 
 
@@ -1219,17 +1219,21 @@ class SuggestReplyInput:
     header_description: typing.Optional[str] = None
     tenant_id: typing.Optional[str] = None
     property_id: typing.Optional[str] = None
-    # Stable identifier for the TenantCloud thread (typically the
+    # Stable identifier for the external chat thread (typically the
     # ``window.location.pathname`` at the time of scraping). Used to
     # mirror the thread as a read-only rentmate Conversation so the
     # AgentRun is grouped under one row in DevTools and so re-clicking
     # ``Suggest`` for the same thread doesn't duplicate messages.
     external_thread_id: typing.Optional[str] = None
-    # Text the PM has already typed into TenantCloud's reply box. When
-    # set, the extension button reads "Refine" and the agent is asked
-    # to polish the draft (clarity, tone, missing context) instead of
-    # composing a fresh reply.
+    # Text the PM has already typed into the source platform's reply
+    # box. When set, the extension button reads "Refine" and the agent
+    # is asked to polish the draft (clarity, tone, missing context)
+    # instead of composing a fresh reply.
     draft_text: typing.Optional[str] = None
+    # Optional source platform identifier stored on the mirror
+    # conversation's ``extra.source`` for analytics and future
+    # per-platform behavior. Defaults server-side when omitted.
+    source: typing.Optional[str] = None
 
 
 @strawberry.type

--- a/gql/types.py
+++ b/gql/types.py
@@ -1213,12 +1213,18 @@ class ConversationTurnInput:
 
 @strawberry.input
 class SuggestReplyInput:
-    """Payload the chrome extension sends for a one-shot reply draft."""
+    """Payload the chrome extension sends for a reply draft."""
     conversation_history: typing.List[ConversationTurnInput]
     header_title: typing.Optional[str] = None
     header_description: typing.Optional[str] = None
     tenant_id: typing.Optional[str] = None
     property_id: typing.Optional[str] = None
+    # Stable identifier for the TenantCloud thread (typically the
+    # ``window.location.pathname`` at the time of scraping). Used to
+    # mirror the thread as a read-only rentmate Conversation so the
+    # AgentRun is grouped under one row in DevTools and so re-clicking
+    # ``Suggest`` for the same thread doesn't duplicate messages.
+    external_thread_id: typing.Optional[str] = None
 
 
 @strawberry.type
@@ -1231,3 +1237,7 @@ class SuggestReplyResult:
     # rather than silently shipping fake-looking drafts.
     error: typing.Optional[str] = None
     fallback: bool = False
+    # External UUID of the read-only mirror Conversation backing this
+    # draft. The extension surfaces this as a deep-link to DevTools so
+    # PMs can inspect the agent run and the mirrored history.
+    conversation_external_id: typing.Optional[str] = None

--- a/rentmate/app.py
+++ b/rentmate/app.py
@@ -365,7 +365,6 @@ def create_app(
         CORSMiddleware,
         allow_origins=allow_origins
         or [
-            "https://app.tenantcloud.com",
             "https://rentmate.io",
             "http://localhost:5173",
             "http://localhost:8080",

--- a/rentmate/app.py
+++ b/rentmate/app.py
@@ -352,6 +352,15 @@ def create_app(
     app.include_router(tenant_invite.router)
     app.include_router(tenant_portal.router)
 
+    # In dev (``RENTMATE_ENV=development``) accept chrome-extension://
+    # origins so the unpacked rentmate-for-tenantcloud extension can
+    # call /graphql against a local API without forcing devs to bounce
+    # through the hosted CORS layer. Production gates extension origins
+    # via ``allow_origin_regex`` injected by the hosted middleware.
+    effective_regex = allow_origin_regex
+    if effective_regex is None and os.getenv("RENTMATE_ENV") == "development":
+        effective_regex = r"chrome-extension://[a-z]{32}"
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=allow_origins
@@ -361,7 +370,7 @@ def create_app(
             "http://localhost:5173",
             "http://localhost:8080",
         ],
-        allow_origin_regex=allow_origin_regex,
+        allow_origin_regex=effective_regex,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/rentmate/app.py
+++ b/rentmate/app.py
@@ -353,8 +353,8 @@ def create_app(
     app.include_router(tenant_portal.router)
 
     # In dev (``RENTMATE_ENV=development``) accept chrome-extension://
-    # origins so the unpacked rentmate-for-tenantcloud extension can
-    # call /graphql against a local API without forcing devs to bounce
+    # origins so the unpacked rentmate chrome extension can call
+    # /graphql against a local API without forcing devs to bounce
     # through the hosted CORS layer. Production gates extension origins
     # via ``allow_origin_regex`` injected by the hosted middleware.
     effective_regex = allow_origin_regex

--- a/www/rentmate-ui/src/components/chat/ChatFilterDropdown.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatFilterDropdown.tsx
@@ -16,10 +16,11 @@ import type { TabKey } from './ConvRow';
 export type ChatFilter = 'all' | TabKey;
 
 const FILTER_OPTIONS: { value: ChatFilter; label: string }[] = [
-  { value: 'all',     label: 'All' },
-  { value: 'user_ai', label: 'RentMate' },
-  { value: 'tenant',  label: 'Tenants' },
-  { value: 'vendor',  label: 'Vendors' },
+  { value: 'all',                label: 'All' },
+  { value: 'user_ai',            label: 'RentMate' },
+  { value: 'tenant',             label: 'Tenants' },
+  { value: 'vendor',             label: 'Vendors' },
+  { value: 'mirrored_chat', label: 'Mirrored' },
 ];
 
 const FILTER_LABELS: Record<ChatFilter, string> = Object.fromEntries(

--- a/www/rentmate-ui/src/components/chat/ChatPanel.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatPanel.tsx
@@ -277,7 +277,7 @@ export function ChatPanel({
   // Fetch the conversation's task linkage + conversation_type so the
   // middle pane can show a "Task #N — <title>" header when the loaded
   // conversation belongs to a task, and so we can disable the input for
-  // read-only mirror conversations (TenantCloud thread snapshots).
+  // read-only mirror conversations (external chat thread snapshots).
   useEffect(() => {
     if (!activeConversationId || activeTask) {
       setConvTaskLink(null);
@@ -305,10 +305,11 @@ export function ChatPanel({
     return () => { cancelled = true; };
   }, [activeConversationId, activeTask]);
 
-  // Mirror conversations are snapshots of TenantCloud threads — replies
-  // happen back in TenantCloud, not in rentmate. Disable the composer
-  // and surface a banner so PMs aren't confused why their messages
-  // bounce off the read-only guard in ``chat_service.send_message``.
+  // Mirror conversations are read-only snapshots of threads from
+  // external chat platforms — replies happen on the source platform,
+  // not in rentmate. Disable the composer and surface a banner so PMs
+  // aren't confused why their messages bounce off the read-only guard
+  // in ``chat_service.send_message``.
   const isReadOnlyConv = activeConvType === 'mirrored_chat'
     || activeConvType === 'MIRRORED_CHAT';
 

--- a/www/rentmate-ui/src/components/chat/ChatPanel.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatPanel.tsx
@@ -271,14 +271,17 @@ export function ChatPanel({
   // DB-backed conversation messages (for conversationId-based chats)
   const [convMessages, setConvMessages] = useState<ChatMessage[]>([]);
   const [convTaskLink, setConvTaskLink] = useState<{ taskId: string; taskTitle: string | null } | null>(null);
+  const [activeConvType, setActiveConvType] = useState<string | null>(null);
   const activeConversationId = chatPanel.conversationId;
 
-  // Fetch the conversation's task linkage so the middle pane can show a
-  // "Task #N — <title>" header when the loaded conversation belongs to a
-  // task. Cleared when no conversation is open.
+  // Fetch the conversation's task linkage + conversation_type so the
+  // middle pane can show a "Task #N — <title>" header when the loaded
+  // conversation belongs to a task, and so we can disable the input for
+  // read-only mirror conversations (TenantCloud thread snapshots).
   useEffect(() => {
     if (!activeConversationId || activeTask) {
       setConvTaskLink(null);
+      setActiveConvType(null);
       return;
     }
     let cancelled = false;
@@ -291,12 +294,23 @@ export function ChatPanel({
         } else {
           setConvTaskLink(null);
         }
+        setActiveConvType(conv?.conversationType ?? null);
       })
       .catch(() => {
-        if (!cancelled) setConvTaskLink(null);
+        if (!cancelled) {
+          setConvTaskLink(null);
+          setActiveConvType(null);
+        }
       });
     return () => { cancelled = true; };
   }, [activeConversationId, activeTask]);
+
+  // Mirror conversations are snapshots of TenantCloud threads — replies
+  // happen back in TenantCloud, not in rentmate. Disable the composer
+  // and surface a banner so PMs aren't confused why their messages
+  // bounce off the read-only guard in ``chat_service.send_message``.
+  const isReadOnlyConv = activeConvType === 'mirrored_chat'
+    || activeConvType === 'MIRRORED_CHAT';
 
   useEffect(() => {
     if (activeTask || (activeSuggestion && !activeConversationId)) { setConvMessages([]); return; }
@@ -1326,7 +1340,14 @@ export function ChatPanel({
                     )}
                   </div>
                 )}
+                {isReadOnlyConv ? (
+                <div className="px-4 py-3 text-xs text-muted-foreground bg-muted/40 border-t flex items-center gap-2">
+                  <span className="font-medium">Read-only.</span>
+                  <span>This thread is mirrored from another platform — send your reply there.</span>
+                </div>
+              ) : (
                 <ChatInput ref={chatInputRef} onSend={handleSend} onInsertCleared={handleInsertCleared} placeholder={placeholder} lastSentMessage={lastSentMessage} disabled={isTyping} uploadFile={uploadFile} attachments={pendingAttachments} setAttachments={setPendingAttachments} />
+              )}
               </div>
             )}
           </TabsContent>
@@ -1654,7 +1675,14 @@ export function ChatPanel({
                   }}
                 />
               )}
-              <ChatInput ref={chatInputRef} onSend={handleSend} onInsertCleared={handleInsertCleared} placeholder={placeholder} lastSentMessage={lastSentMessage} disabled={isTyping} uploadFile={uploadFile} attachments={pendingAttachments} setAttachments={setPendingAttachments} />
+              {isReadOnlyConv ? (
+                <div className="px-4 py-3 text-xs text-muted-foreground bg-muted/40 border-t flex items-center gap-2">
+                  <span className="font-medium">Read-only.</span>
+                  <span>This thread is mirrored from another platform — send your reply there.</span>
+                </div>
+              ) : (
+                <ChatInput ref={chatInputRef} onSend={handleSend} onInsertCleared={handleInsertCleared} placeholder={placeholder} lastSentMessage={lastSentMessage} disabled={isTyping} uploadFile={uploadFile} attachments={pendingAttachments} setAttachments={setPendingAttachments} />
+              )}
             </>
           ) : (
             <ChatInput ref={chatInputRef} onSend={handleSend} onInsertCleared={handleInsertCleared} placeholder={placeholder} lastSentMessage={lastSentMessage} disabled={isTyping} uploadFile={uploadFile} attachments={pendingAttachments} setAttachments={setPendingAttachments} />

--- a/www/rentmate-ui/src/components/chat/ConvRow.tsx
+++ b/www/rentmate-ui/src/components/chat/ConvRow.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Bot, MessageCircle, Building2, Trash2, ClipboardList } from 'lucide-react';
+import { Bot, MessageCircle, Building2, Trash2, ClipboardList, Cloud, Lock } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 
 export interface ConvSummary {
@@ -19,24 +19,27 @@ export interface ConvSummary {
   taskTitle?: string | null;
 }
 
-export type TabKey = 'user_ai' | 'tenant' | 'vendor';
+export type TabKey = 'user_ai' | 'tenant' | 'vendor' | 'mirrored_chat';
 
 export const TAB_CONFIG: { key: TabKey; label: string; icon: React.ElementType }[] = [
   { key: 'user_ai', label: 'With RentMate', icon: Bot },
   { key: 'tenant', label: 'Tenants', icon: MessageCircle },
   { key: 'vendor', label: 'Vendors', icon: Building2 },
+  { key: 'mirrored_chat', label: 'Mirrored', icon: Cloud },
 ];
 
 export const typeLabels: Record<string, string> = {
   user_ai: 'RentMate',
   tenant: 'Tenant',
   vendor: 'Vendor',
+  mirrored_chat: 'Mirrored',
 };
 
 export const typeColors: Record<string, string> = {
   user_ai: 'bg-primary/10 text-primary',
   tenant: 'bg-green-800/15 text-green-700 dark:text-green-400',
   vendor: 'bg-orange-100 text-orange-700 dark:bg-orange-900/20 dark:text-orange-400',
+  mirrored_chat: 'bg-sky-100 text-sky-700 dark:bg-sky-900/20 dark:text-sky-400',
 };
 
 export function ConvRow({ conv, onClick, onDelete, isActive }: { conv: ConvSummary; onClick: () => void; onDelete?: () => void; isActive?: boolean }) {
@@ -48,6 +51,7 @@ export function ConvRow({ conv, onClick, onDelete, isActive }: { conv: ConvSumma
   // title; the stored ``subject`` varies (e.g. "Chat with X" vs
   // "Message X: <task>") and is unreliable for display.
   const isExternalConv = conv.conversationType === 'tenant' || conv.conversationType === 'vendor';
+  const isMirror = conv.conversationType === 'mirrored_chat';
   const displayTitle = isExternalConv
     ? (conv.participantLabel ?? conv.title)
     : conv.title;
@@ -83,6 +87,16 @@ export function ConvRow({ conv, onClick, onDelete, isActive }: { conv: ConvSumma
           {conv.unreadCount > 0 && (
             <Badge className="h-4 px-1.5 text-[10px] bg-primary text-primary-foreground shrink-0">
               {conv.unreadCount} new
+            </Badge>
+          )}
+          {isMirror && (
+            <Badge
+              variant="secondary"
+              className="text-[10px] rounded-lg gap-1 shrink-0 bg-muted text-muted-foreground"
+              title="Mirrored from another platform — replies must happen there"
+            >
+              <Lock className="h-3 w-3" />
+              Read-only
             </Badge>
           )}
         </div>

--- a/www/rentmate-ui/src/graphql/generated.ts
+++ b/www/rentmate-ui/src/graphql/generated.ts
@@ -114,6 +114,7 @@ export type ConversationType =
   | 'SUGGESTION_AI'
   | 'TASK_AI'
   | 'TENANT'
+  | 'TENANTCLOUD_MIRROR'
   | 'USER_AI'
   | 'VENDOR';
 
@@ -289,7 +290,7 @@ export type Mutation = {
   simulateRoutine: Scalars['String']['output'];
   /** Spawn a Task from an existing conversation, linking lineage */
   spawnTask: TaskType;
-  /** One-shot agent-drafted reply for a TenantCloud conversation viewed in the chrome extension. Pure read on rentmate data — no DB writes. */
+  /** Agent-drafted reply for a TenantCloud conversation viewed in the chrome extension. When ``externalThreadId`` is provided the thread is mirrored into rentmate as a read-only conversation so the AgentRun is groupable in DevTools and re-clicking ``Suggest`` doesn't duplicate messages. */
   suggestReply: SuggestReplyResult;
   /** Update the agent context for any entity (property, unit, tenant, vendor) */
   updateEntityContext: Scalars['Boolean']['output'];
@@ -636,6 +637,7 @@ export type SpawnTaskInput = {
 
 export type SuggestReplyInput = {
   conversationHistory: Array<ConversationTurnInput>;
+  externalThreadId: InputMaybe<Scalars['String']['input']>;
   headerDescription: InputMaybe<Scalars['String']['input']>;
   headerTitle: InputMaybe<Scalars['String']['input']>;
   propertyId: InputMaybe<Scalars['String']['input']>;
@@ -643,6 +645,7 @@ export type SuggestReplyInput = {
 };
 
 export type SuggestReplyResult = {
+  conversationExternalId: Maybe<Scalars['String']['output']>;
   error: Maybe<Scalars['String']['output']>;
   fallback: Scalars['Boolean']['output'];
   matchedTenant: Maybe<TenantSearchResult>;

--- a/www/rentmate-ui/src/graphql/generated.ts
+++ b/www/rentmate-ui/src/graphql/generated.ts
@@ -111,10 +111,10 @@ export type ConversationTurnInput = {
 };
 
 export type ConversationType =
+  | 'MIRRORED_CHAT'
   | 'SUGGESTION_AI'
   | 'TASK_AI'
   | 'TENANT'
-  | 'TENANTCLOUD_MIRROR'
   | 'USER_AI'
   | 'VENDOR';
 

--- a/www/rentmate-ui/src/graphql/generated.ts
+++ b/www/rentmate-ui/src/graphql/generated.ts
@@ -637,6 +637,7 @@ export type SpawnTaskInput = {
 
 export type SuggestReplyInput = {
   conversationHistory: Array<ConversationTurnInput>;
+  draftText: InputMaybe<Scalars['String']['input']>;
   externalThreadId: InputMaybe<Scalars['String']['input']>;
   headerDescription: InputMaybe<Scalars['String']['input']>;
   headerTitle: InputMaybe<Scalars['String']['input']>;

--- a/www/rentmate-ui/src/graphql/generated.ts
+++ b/www/rentmate-ui/src/graphql/generated.ts
@@ -290,7 +290,7 @@ export type Mutation = {
   simulateRoutine: Scalars['String']['output'];
   /** Spawn a Task from an existing conversation, linking lineage */
   spawnTask: TaskType;
-  /** Agent-drafted reply for a TenantCloud conversation viewed in the chrome extension. When ``externalThreadId`` is provided the thread is mirrored into rentmate as a read-only conversation so the AgentRun is groupable in DevTools and re-clicking ``Suggest`` doesn't duplicate messages. */
+  /** Agent-drafted reply for a conversation in an external chat tool, viewed via the chrome extension. When ``externalThreadId`` is provided the thread is mirrored into rentmate as a read-only conversation so the AgentRun is groupable in DevTools and re-clicking ``Suggest`` doesn't duplicate messages. */
   suggestReply: SuggestReplyResult;
   /** Update the agent context for any entity (property, unit, tenant, vendor) */
   updateEntityContext: Scalars['Boolean']['output'];
@@ -642,6 +642,7 @@ export type SuggestReplyInput = {
   headerDescription: InputMaybe<Scalars['String']['input']>;
   headerTitle: InputMaybe<Scalars['String']['input']>;
   propertyId: InputMaybe<Scalars['String']['input']>;
+  source: InputMaybe<Scalars['String']['input']>;
   tenantId: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/www/rentmate-ui/src/graphql/schema.graphql
+++ b/www/rentmate-ui/src/graphql/schema.graphql
@@ -329,7 +329,7 @@ type Mutation {
   spawnTask(input: SpawnTaskInput!): TaskType!
 
   """
-  Agent-drafted reply for a TenantCloud conversation viewed in the chrome extension. When ``externalThreadId`` is provided the thread is mirrored into rentmate as a read-only conversation so the AgentRun is groupable in DevTools and re-clicking ``Suggest`` doesn't duplicate messages.
+  Agent-drafted reply for a conversation in an external chat tool, viewed via the chrome extension. When ``externalThreadId`` is provided the thread is mirrored into rentmate as a read-only conversation so the AgentRun is groupable in DevTools and re-clicking ``Suggest`` doesn't duplicate messages.
   """
   suggestReply(input: SuggestReplyInput!): SuggestReplyResult!
 }
@@ -438,6 +438,7 @@ input SuggestReplyInput {
   propertyId: String = null
   externalThreadId: String = null
   draftText: String = null
+  source: String = null
 }
 
 type SuggestReplyResult {

--- a/www/rentmate-ui/src/graphql/schema.graphql
+++ b/www/rentmate-ui/src/graphql/schema.graphql
@@ -97,6 +97,7 @@ enum ConversationType {
   USER_AI
   TASK_AI
   SUGGESTION_AI
+  TENANTCLOUD_MIRROR
 }
 
 input CreatePropertyInput {
@@ -328,7 +329,7 @@ type Mutation {
   spawnTask(input: SpawnTaskInput!): TaskType!
 
   """
-  One-shot agent-drafted reply for a TenantCloud conversation viewed in the chrome extension. Pure read on rentmate data — no DB writes.
+  Agent-drafted reply for a TenantCloud conversation viewed in the chrome extension. When ``externalThreadId`` is provided the thread is mirrored into rentmate as a read-only conversation so the AgentRun is groupable in DevTools and re-clicking ``Suggest`` doesn't duplicate messages.
   """
   suggestReply(input: SuggestReplyInput!): SuggestReplyResult!
 }
@@ -435,6 +436,7 @@ input SuggestReplyInput {
   headerDescription: String = null
   tenantId: String = null
   propertyId: String = null
+  externalThreadId: String = null
 }
 
 type SuggestReplyResult {
@@ -442,6 +444,7 @@ type SuggestReplyResult {
   matchedTenant: TenantSearchResult
   error: String
   fallback: Boolean!
+  conversationExternalId: String
 }
 
 enum SuggestionSource {

--- a/www/rentmate-ui/src/graphql/schema.graphql
+++ b/www/rentmate-ui/src/graphql/schema.graphql
@@ -437,6 +437,7 @@ input SuggestReplyInput {
   tenantId: String = null
   propertyId: String = null
   externalThreadId: String = null
+  draftText: String = null
 }
 
 type SuggestReplyResult {

--- a/www/rentmate-ui/src/graphql/schema.graphql
+++ b/www/rentmate-ui/src/graphql/schema.graphql
@@ -97,7 +97,7 @@ enum ConversationType {
   USER_AI
   TASK_AI
   SUGGESTION_AI
-  TENANTCLOUD_MIRROR
+  MIRRORED_CHAT
 }
 
 input CreatePropertyInput {

--- a/www/rentmate-ui/src/pages/Chats.tsx
+++ b/www/rentmate-ui/src/pages/Chats.tsx
@@ -25,23 +25,30 @@ const Chats = () => {
     openChat({ suggestionId });
   }, [openChat, suggestionId, suggestions]);
 
-  // Always fetch all three buckets so flipping the filter is instant —
+  // Always fetch all four buckets so flipping the filter is instant —
   // the cost is one extra round-trip up front and lets us merge for the
   // "All" view without re-querying.
   const ai = useConversations('user_ai');
   const tenants = useConversations('tenant');
   const vendors = useConversations('vendor');
+  const tenantcloud = useConversations('mirrored_chat');
 
   const sources: Record<ChatFilter, ReturnType<typeof useConversations>> = {
     all: ai, // placeholder, overridden below
     user_ai: ai,
     tenant: tenants,
     vendor: vendors,
+    mirrored_chat: tenantcloud,
   };
 
   const conversations = useMemo(() => {
     if (filter === 'all') {
-      return [...ai.conversations, ...tenants.conversations, ...vendors.conversations].sort(
+      return [
+        ...ai.conversations,
+        ...tenants.conversations,
+        ...vendors.conversations,
+        ...tenantcloud.conversations,
+      ].sort(
         (a, b) => {
           const at = a.lastMessageAt ?? a.updatedAt;
           const bt = b.lastMessageAt ?? b.updatedAt;
@@ -50,11 +57,18 @@ const Chats = () => {
       );
     }
     return sources[filter].conversations;
-  }, [filter, ai.conversations, tenants.conversations, vendors.conversations, sources]);
+  }, [
+    filter,
+    ai.conversations,
+    tenants.conversations,
+    vendors.conversations,
+    tenantcloud.conversations,
+    sources,
+  ]);
 
   const loading =
     filter === 'all'
-      ? ai.loading || tenants.loading || vendors.loading
+      ? ai.loading || tenants.loading || vendors.loading || tenantcloud.loading
       : sources[filter].loading;
 
   // Removing a conversation needs to drop it from whichever list owns it.
@@ -62,6 +76,7 @@ const Chats = () => {
     ai.removeConversation(uid);
     tenants.removeConversation(uid);
     vendors.removeConversation(uid);
+    tenantcloud.removeConversation(uid);
   };
 
   const leftRail = (

--- a/www/rentmate-ui/src/pages/Chats.tsx
+++ b/www/rentmate-ui/src/pages/Chats.tsx
@@ -31,14 +31,14 @@ const Chats = () => {
   const ai = useConversations('user_ai');
   const tenants = useConversations('tenant');
   const vendors = useConversations('vendor');
-  const tenantcloud = useConversations('mirrored_chat');
+  const mirrored = useConversations('mirrored_chat');
 
   const sources: Record<ChatFilter, ReturnType<typeof useConversations>> = {
     all: ai, // placeholder, overridden below
     user_ai: ai,
     tenant: tenants,
     vendor: vendors,
-    mirrored_chat: tenantcloud,
+    mirrored_chat: mirrored,
   };
 
   const conversations = useMemo(() => {
@@ -47,7 +47,7 @@ const Chats = () => {
         ...ai.conversations,
         ...tenants.conversations,
         ...vendors.conversations,
-        ...tenantcloud.conversations,
+        ...mirrored.conversations,
       ].sort(
         (a, b) => {
           const at = a.lastMessageAt ?? a.updatedAt;
@@ -62,13 +62,13 @@ const Chats = () => {
     ai.conversations,
     tenants.conversations,
     vendors.conversations,
-    tenantcloud.conversations,
+    mirrored.conversations,
     sources,
   ]);
 
   const loading =
     filter === 'all'
-      ? ai.loading || tenants.loading || vendors.loading || tenantcloud.loading
+      ? ai.loading || tenants.loading || vendors.loading || mirrored.loading
       : sources[filter].loading;
 
   // Removing a conversation needs to drop it from whichever list owns it.
@@ -76,7 +76,7 @@ const Chats = () => {
     ai.removeConversation(uid);
     tenants.removeConversation(uid);
     vendors.removeConversation(uid);
-    tenantcloud.removeConversation(uid);
+    mirrored.removeConversation(uid);
   };
 
   const leftRail = (


### PR DESCRIPTION
## Summary

- The chrome extension's `suggestReply` mutation now drives the actual rentmate agent (instead of a one-shot LiteLLM call) so the invocation appears in DevTools as an AgentRun.
- The thread is mirrored into rentmate as a read-only conversation keyed by `externalThreadId`. Re-clicking Suggest for the same thread reuses the existing conversation and dedup-inserts only new turns.
- `chat_service.send_message` / `send_autonomous_message` raise `MirrorConversationReadOnly` for mirror conversations — replies must happen in external, not rentmate.
- Legacy extension versions without `externalThreadId` still get a draft via the original one-shot LiteLLM path during rollout.

The companion chrome-extension change (scrape `window.location.pathname` and pass `externalThreadId`) lands in rentmate-hosted.

## Test plan

- [x] `pytest gql/services/tests/test_extension_service.py` — 18 passing (8 new)
- [x] Full backend suite (`pytest -q --ignore=evals`) — 674 passing
- [x] Frontend `tsc --noEmit` clean
- [x] Frontend `vitest` — 78 passing
- [x] `tests/test_graphql_codegen.py` — schema + generated.ts regenerated
- [ ] Manual: open a thread in the chrome extension, click Suggest, verify the AgentRun appears in DevTools and a  conversation is created
- [ ] Manual: click Suggest again on the same thread, verify no duplicate messages