### PR TITLE
runs/traces: migrate to Harbor ATIF v1.4 trajectory format

### DIFF
--- a/db/migrations/versions/d3f5a6b7c8d9_add_agent_steps.py
+++ b/db/migrations/versions/d3f5a6b7c8d9_add_agent_steps.py
@@ -1,0 +1,68 @@
+"""add agent_steps table for ATIF v1.4 trajectory persistence
+
+Adds the ``agent_steps`` table that maps 1:1 to a Harbor Framework ATIF
+Step. The old ``agent_traces`` table is intentionally left in place — a
+read-time adapter in ``llm/trajectory.py`` synthesizes ATIF trajectories
+from pre-cutover trace rows, so historical runs keep rendering in
+DevTools without a data migration. A follow-up migration drops
+``agent_traces`` once that historical replay value expires.
+
+Revision ID: d3f5a6b7c8d9
+Revises: c2f3e4d5a6b8
+Create Date: 2026-04-28
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "d3f5a6b7c8d9"
+down_revision: Union[str, None] = "c2f3e4d5a6b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_steps",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("org_id", sa.Integer, nullable=False, index=True),
+        sa.Column("creator_id", sa.Integer, nullable=False),
+        sa.Column("run_id", sa.String(36), nullable=False, index=True),
+        sa.Column("step_id", sa.Integer, nullable=False),
+        sa.Column("timestamp", sa.DateTime, nullable=False, index=True),
+        sa.Column("source", sa.String(8), nullable=False),
+        sa.Column("message", sa.Text, nullable=False),
+        sa.Column("model_name", sa.String(128), nullable=True),
+        sa.Column("reasoning_content", sa.Text, nullable=True),
+        sa.Column("tool_calls", postgresql.JSONB, nullable=True),
+        sa.Column("observation", postgresql.JSONB, nullable=True),
+        sa.Column("metrics", postgresql.JSONB, nullable=True),
+        sa.Column(
+            "extra", postgresql.JSONB, nullable=False, server_default="{}"
+        ),
+        sa.UniqueConstraint("org_id", "id", name="uq_agent_steps_org"),
+        sa.UniqueConstraint(
+            "org_id", "run_id", "step_id", name="uq_agent_steps_run_step"
+        ),
+        sa.ForeignKeyConstraint(
+            ["org_id", "creator_id"],
+            ["users.org_id", "users.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["org_id", "run_id"],
+            ["agent_runs.org_id", "agent_runs.id"],
+            name="fk_agent_steps_run",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index(
+        "ix_agent_steps_run_step", "agent_steps", ["run_id", "step_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_steps_run_step", table_name="agent_steps")
+    op.drop_table("agent_steps")

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -26,6 +26,7 @@ from db.enums import (
 from .account import User
 from .agent_memory import AgentMemory
 from .agent_run import AgentRun, AgentRunFlag, AgentRunReview
+from .agent_step import AgentStep
 from .agent_trace import AgentTrace
 
 # AutomationRevision removed — replaced by Routine
@@ -76,6 +77,7 @@ __all__ = [
     "AgentRun",
     "AgentRunFlag",
     "AgentRunReview",
+    "AgentStep",
     "AgentTrace",
     "MemoryItem",
     "AppSetting",

--- a/db/models/agent_step.py
+++ b/db/models/agent_step.py
@@ -1,0 +1,89 @@
+"""ATIF v1.4-shaped step rows for agent runs.
+
+Each ``AgentStep`` is one entry in a Harbor Framework trajectory: a
+``user`` / ``agent`` / ``system`` turn with optional tool calls, an
+observation block, and per-step token / cost metrics. Replaces the old
+``AgentTrace`` row-per-event model where a single agent turn could fan
+out to many heterogeneous traces (``tool_call``, ``tool_result``,
+``error`` …).
+
+ATIF spec: https://www.harborframework.com/docs/agents/trajectory-format
+"""
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import relationship
+
+from .base import Base, HasCreatorId, OrgId, PrimaryId
+
+
+class AgentStep(Base, OrgId, PrimaryId, HasCreatorId):
+    """One ATIF Step inside an ``AgentRun`` trajectory.
+
+    ``step_id`` is the ATIF-spec sequential integer (1, 2, 3, …) per run;
+    rentmate's UUID ``id`` is the row primary key, so the two never
+    collide. Composite FK to ``agent_runs(org_id, id)`` cascade-deletes
+    steps when their owning run is removed.
+    """
+
+    __tablename__ = "agent_steps"
+
+    run_id = Column(String(36), nullable=False, index=True)
+    # ATIF: sequential int starting at 1.
+    step_id = Column(Integer, nullable=False)
+    timestamp = Column(DateTime, nullable=False, index=True)
+    # ATIF: "user" | "agent" | "system".
+    source = Column(String(8), nullable=False)
+    message = Column(Text, nullable=False)
+
+    # Agent-step-only fields (nullable on user/system steps).
+    model_name = Column(String(128), nullable=True)
+    # TODO(atif): populated once the per-provider chain-of-thought shim
+    # lands (Anthropic <thinking>, OpenAI reasoning_content, …).
+    reasoning_content = Column(Text, nullable=True)
+    # ATIF ToolCall[] — list of {tool_call_id, function_name, arguments}.
+    tool_calls = Column(JSONB, nullable=True)
+    # ATIF Observation — {results: [{source_call_id, content}]}.
+    observation = Column(JSONB, nullable=True)
+    # ATIF Metrics — {prompt_tokens, completion_tokens, cached_tokens?, cost_usd}.
+    metrics = Column(JSONB, nullable=True)
+
+    # Rentmate-internal slot for fields that don't fit ATIF (error_kind,
+    # legacy trace_type, tool durations, …). Surfaced under ATIF's
+    # top-level ``extra`` on serialization.
+    extra = Column(JSONB, nullable=False, default=dict)
+
+    run = relationship(
+        "AgentRun",
+        primaryjoin=(
+            "and_(AgentStep.org_id==AgentRun.org_id, "
+            "AgentStep.run_id==AgentRun.id)"
+        ),
+        viewonly=True,
+    )
+
+    __table_args__ = (
+        UniqueConstraint("org_id", "id", name="uq_agent_steps_org"),
+        UniqueConstraint(
+            "org_id", "run_id", "step_id", name="uq_agent_steps_run_step"
+        ),
+        Index("ix_agent_steps_run_step", "run_id", "step_id"),
+        ForeignKeyConstraint(
+            ["org_id", "creator_id"],
+            ["users.org_id", "users.id"],
+        ),
+        ForeignKeyConstraint(
+            ["org_id", "run_id"],
+            ["agent_runs.org_id", "agent_runs.id"],
+            name="fk_agent_steps_run",
+            ondelete="CASCADE",
+        ),
+    )

--- a/db/models/agent_trace.py
+++ b/db/models/agent_trace.py
@@ -3,6 +3,11 @@
 Each row belongs to exactly one ``AgentRun`` (composite ``(org_id, run_id)`` FK).
 Grouping keys (``task_id``, ``conversation_id``) live on the run, not here —
 filter via JOIN.
+
+# TODO(atif): drop this table once pre-cutover runs no longer need
+# rendering. Post-cutover writers go to ``agent_steps`` via
+# ``llm/trajectory.py``; legacy rows are read by
+# ``_synthesize_steps_from_traces`` to keep historical DevTools views.
 """
 from sqlalchemy import (
     Column,

--- a/handlers/dev.py
+++ b/handlers/dev.py
@@ -300,24 +300,36 @@ async def list_runs(
     status: str | None = None,
     limit: int = 50,
 ):
-    """Return recent agent runs (newest first) with per-run trace counts.
+    """Return recent agent runs (newest first) with per-run step + trace counts.
 
-    The dev UI groups traces by run; this endpoint feeds the collapsed
-    run rows. Per-run traces come from ``GET /dev/traces?run_id=...``.
+    The dev UI groups events by run; per-run trajectory comes from
+    ``GET /dev/runs/{run_id}/trajectory`` (ATIF v1.4). ``step_count`` is
+    the post-cutover ATIF step count; ``trace_count`` is the legacy
+    AgentTrace count for runs that pre-date the trajectory rewrite.
     """
     await require_user(request)
     from sqlalchemy import func, select
 
-    from db.models import AgentRun, AgentTrace
+    from db.models import AgentRun, AgentStep, AgentTrace
 
     trace_count_subq = (
         select(AgentTrace.run_id, func.count().label("trace_count"))
         .group_by(AgentTrace.run_id)
         .subquery()
     )
+    step_count_subq = (
+        select(AgentStep.run_id, func.count().label("step_count"))
+        .group_by(AgentStep.run_id)
+        .subquery()
+    )
     q = (
-        select(AgentRun, trace_count_subq.c.trace_count)
+        select(
+            AgentRun,
+            trace_count_subq.c.trace_count,
+            step_count_subq.c.step_count,
+        )
         .outerjoin(trace_count_subq, trace_count_subq.c.run_id == AgentRun.id)
+        .outerjoin(step_count_subq, step_count_subq.c.run_id == AgentRun.id)
         .order_by(AgentRun.started_at.desc())
     )
     if task_id:
@@ -332,7 +344,7 @@ async def list_runs(
 
     rows = db.execute(q).all()
     out: list[dict] = []
-    for run, trace_count in rows:
+    for run, trace_count, step_count in rows:
         duration_ms: int | None = None
         if run.ended_at and run.started_at:
             duration_ms = int((run.ended_at - run.started_at).total_seconds() * 1000)
@@ -355,9 +367,32 @@ async def list_runs(
             "trigger_input": (run.trigger_input or "")[:240] or None,
             "final_response": (run.final_response or "")[:240] or None,
             "error_message": run.error_message,
+            "step_count": int(step_count or 0),
             "trace_count": int(trace_count or 0),
         })
     return out
+
+
+@router.get("/runs/{run_id}/trajectory")
+async def get_run_trajectory(
+    run_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """Return the run's full ATIF v1.4 trajectory.
+
+    Reads from ``agent_steps`` for post-cutover runs; falls back to a
+    legacy adapter that synthesizes ATIF Steps from ``agent_traces`` for
+    runs that pre-date the trajectory rewrite. See
+    ``llm/trajectory.py:to_trajectory``.
+    """
+    await require_user(request)
+    from llm.trajectory import to_trajectory
+
+    trajectory = to_trajectory(db, run_id)
+    if trajectory is None:
+        raise HTTPException(status_code=404, detail=f"run {run_id} not found")
+    return trajectory
 
 
 @router.get("/trace-filters/tasks")

--- a/llm/client.py
+++ b/llm/client.py
@@ -574,6 +574,7 @@ async def chat_with_agent(
     _trace_conversation_id = str((trace_context or {}).get("conversation_id") or "") or None
 
     def _tool_progress(event_type: str, tool_name: str, preview: str | None, args: dict | None, **kwargs):
+        from llm.trajectory import current_step_builder
         label = _TOOL_LABELS.get(tool_name, tool_name)
         trace_detail = current_trace_context.get() or trace_context or {}
         if event_type == "tool.started":
@@ -631,19 +632,25 @@ async def chat_with_agent(
             msg = f"{label}{hint}"
             progress_events.append(msg)
             progress_queue.put(msg)
-            log_trace(
-                "tool_call",
-                _trace_source,
-                msg,
-                tool_name=tool_name,
-                detail=make_trace_envelope(
+            # The ATIF tool_call entry is created at completion (when we
+            # have the real ``tool_call_id`` from litellm). For runs not
+            # wrapped in an active step builder — e.g. background paths
+            # that haven't migrated yet — fall back to the legacy
+            # AgentTrace shim so DevTools' historical view stays intact.
+            if current_step_builder() is None:
+                log_trace(
                     "tool_call",
+                    _trace_source,
+                    msg,
                     tool_name=tool_name,
-                    args=args or {},
-                    preview=preview,
-                    trace_context=trace_detail,
-                ),
-            )
+                    detail=make_trace_envelope(
+                        "tool_call",
+                        tool_name=tool_name,
+                        args=args or {},
+                        preview=preview,
+                        trace_context=trace_detail,
+                    ),
+                )
         elif event_type == "tool.completed":
             # All "tool.completed" bookkeeping (failed/completed contextvars,
             # progress events, trace rows) happens in ``_tool_complete_cb``
@@ -658,13 +665,15 @@ async def chat_with_agent(
         """Fires right after tool.completed with the real result string.
 
         Parses the tool's return payload to extract success/error status and
-        any ``message`` / ``error`` field, then logs a trace row and pushes a
-        progress event that actually contains the detail the user needs to
-        diagnose a failure.
+        any ``message`` / ``error`` field, then attaches the call + observation
+        to the active ATIF step builder (or falls back to the legacy
+        AgentTrace shim if no builder is open).
         """
+        from llm.trajectory import current_step_builder
         try:
             label = _TOOL_LABELS.get(function_name, function_name)
             trace_detail = current_trace_context.get() or trace_context or {}
+            builder = current_step_builder()
 
             result_text = function_result if isinstance(function_result, str) else str(function_result or "")
             is_error = False
@@ -698,42 +707,68 @@ async def chat_with_agent(
                     "error": error_message or result_text,
                 })
                 current_failed_tools.set(failed)
-                log_trace(
-                    "error",
-                    _trace_source,
-                    msg,
-                    tool_name=function_name,
-                    detail=make_trace_envelope(
-                        "tool_error",
+                if builder is not None:
+                    builder.add_tool_call(
+                        tool_call_id=str(tool_call_id),
+                        function_name=function_name,
+                        arguments=function_args or {},
+                    )
+                    err_text = error_message or result_text or ""
+                    if isinstance(err_text, str) and len(err_text) > 500:
+                        err_text = err_text[:500] + "…"
+                    builder.add_observation(
+                        source_call_id=str(tool_call_id),
+                        content=f"ERROR: {err_text}",
+                    )
+                    builder.add_extra("error_kind", "tool_error")
+                else:
+                    log_trace(
+                        "error",
+                        _trace_source,
+                        msg,
                         tool_name=function_name,
-                        args=function_args or {},
-                        error=error_message or result_text,
-                        result=result_text,
-                        trace_context=trace_detail,
-                    ),
-                )
+                        detail=make_trace_envelope(
+                            "tool_error",
+                            tool_name=function_name,
+                            args=function_args or {},
+                            error=error_message or result_text,
+                            result=result_text,
+                            trace_context=trace_detail,
+                        ),
+                    )
                 return
 
-            # Success path — record completion + log the (truncated) result.
+            # Success path — record completion + emit the (truncated) result.
             completed = list(current_completed_tools.get())
             completed.append(function_name)
             current_completed_tools.set(completed)
             trimmed = result_text
             if len(trimmed) > 500:
                 trimmed = trimmed[:500] + "…"
-            log_trace(
-                "tool_result",
-                _trace_source,
-                f"{label} completed",
-                tool_name=function_name,
-                detail=make_trace_envelope(
+            if builder is not None:
+                builder.add_tool_call(
+                    tool_call_id=str(tool_call_id),
+                    function_name=function_name,
+                    arguments=function_args or {},
+                )
+                builder.add_observation(
+                    source_call_id=str(tool_call_id),
+                    content=trimmed,
+                )
+            else:
+                log_trace(
                     "tool_result",
+                    _trace_source,
+                    f"{label} completed",
                     tool_name=function_name,
-                    args=function_args or {},
-                    result=trimmed,
-                    trace_context=trace_detail,
-                ),
-            )
+                    detail=make_trace_envelope(
+                        "tool_result",
+                        tool_name=function_name,
+                        args=function_args or {},
+                        result=trimmed,
+                        trace_context=trace_detail,
+                    ),
+                )
         except Exception:
             # Never let trace plumbing break tool execution.
             pass
@@ -934,6 +969,33 @@ async def _sync_request(payload: dict) -> AgentResponse:
         )
 
 
+async def _agent_turn(
+    agent_id: str,
+    session_key: str,
+    messages: list[dict],
+    on_progress: Optional[Callable],
+    *,
+    trace_context: dict[str, Any] | None,
+    model_name: str | None,
+) -> str:
+    """Run one agent turn inside an ATIF ``begin_agent_step`` context.
+
+    Tool-dispatch callbacks pull the active builder off the contextvar
+    and attach tool_calls + observations onto the same step row, so a
+    multi-tool turn collapses to one ATIF Step. Token totals from
+    ``litellm.acompletion`` flow into the run handle and the step
+    builder derives its ``metrics`` from the delta on context exit.
+    """
+    from llm.trajectory import begin_agent_step
+    with begin_agent_step("", model_name=model_name) as step:
+        reply = await chat_with_agent(
+            agent_id, session_key, messages, on_progress, trace_context=trace_context,
+        )
+        if step is not None:
+            step.update_message(reply or "")
+        return reply
+
+
 async def _local_fallback(
     agent_id: str,
     session_key: str,
@@ -965,12 +1027,17 @@ async def _local_fallback(
         conversation_id=str((trace_context or {}).get("conversation_id") or "") or None,
     )
 
+    _model_for_step = run_metadata.get("model")
+
     try:
         with start_run(
             **run_metadata,
             trigger_input=latest_user,
         ) as run:
-            reply = await chat_with_agent(agent_id, session_key, messages, on_progress, trace_context=trace_context)
+            reply = await _agent_turn(
+                agent_id, session_key, messages, on_progress,
+                trace_context=trace_context, model_name=_model_for_step,
+            )
             side_effects = _collect_pending_side_effects(pending_items=pending_suggestion_messages.get())
             failed_tools = list(current_failed_tools.get())
             completed_tools = list(current_completed_tools.get())
@@ -979,16 +1046,15 @@ async def _local_fallback(
                 latest_user_message=latest_user,
                 side_effects=side_effects,
             ):
-                log_trace(
-                    "error",
-                    "chat",
+                from llm.trajectory import record_step
+                record_step(
+                    "system",
                     "Assistant said tenant access needed checking without message_person",
-                    detail=make_trace_envelope(
-                        "tool_enforcement",
-                        expected_tool="message_person",
-                        reply=reply,
-                        trace_context=trace_context,
-                    ),
+                    extra={
+                        "kind": "tool_enforcement",
+                        "expected_tool": "message_person",
+                        "reply": reply,
+                    },
                 )
                 pending_suggestion_messages.set([])
                 current_failed_tools.set([])
@@ -1005,12 +1071,9 @@ async def _local_fallback(
                         ),
                     },
                 ]
-                reply = await chat_with_agent(
-                    agent_id,
-                    session_key,
-                    corrective_messages,
-                    on_progress,
-                    trace_context=trace_context,
+                reply = await _agent_turn(
+                    agent_id, session_key, corrective_messages, on_progress,
+                    trace_context=trace_context, model_name=_model_for_step,
                 )
                 side_effects = _collect_pending_side_effects(pending_items=pending_suggestion_messages.get())
                 failed_tools = list(current_failed_tools.get())
@@ -1021,16 +1084,15 @@ async def _local_fallback(
                     reply = side_effect_reply
                     run.complete(status="completed", final_response=reply)
                     return AgentResponse(reply=reply, side_effects=side_effects)
-                log_trace(
-                    "error",
-                    "chat",
+                from llm.trajectory import record_step
+                record_step(
+                    "system",
                     "Assistant claimed document creation without create_document tool call",
-                    detail=make_trace_envelope(
-                        "tool_enforcement",
-                        expected_tool="create_document",
-                        reply=reply,
-                        trace_context=trace_context,
-                    ),
+                    extra={
+                        "kind": "tool_enforcement",
+                        "expected_tool": "create_document",
+                        "reply": reply,
+                    },
                 )
                 pending_suggestion_messages.set([])
                 corrective_messages = [
@@ -1045,12 +1107,9 @@ async def _local_fallback(
                         ),
                     },
                 ]
-                reply = await chat_with_agent(
-                    agent_id,
-                    session_key,
-                    corrective_messages,
-                    on_progress,
-                    trace_context=trace_context,
+                reply = await _agent_turn(
+                    agent_id, session_key, corrective_messages, on_progress,
+                    trace_context=trace_context, model_name=_model_for_step,
                 )
                 side_effects = _collect_pending_side_effects(pending_items=pending_suggestion_messages.get())
                 if _reply_claims_document_created(reply) and not _has_document_side_effect(side_effects):
@@ -1064,17 +1123,16 @@ async def _local_fallback(
             )
             if switched_mutating_tool:
                 failed_tool, replacement_tool = switched_mutating_tool
-                log_trace(
-                    "error",
-                    "chat",
+                from llm.trajectory import record_step
+                record_step(
+                    "system",
                     "Assistant switched to a different mutating tool after tool failure",
-                    detail=make_trace_envelope(
-                        "tool_enforcement",
-                        failed_tool=failed_tool,
-                        replacement_tool=replacement_tool,
-                        reply=reply,
-                        trace_context=trace_context,
-                    ),
+                    extra={
+                        "kind": "tool_enforcement",
+                        "failed_tool": failed_tool,
+                        "replacement_tool": replacement_tool,
+                        "reply": reply,
+                    },
                 )
                 pending_suggestion_messages.set([])
                 current_failed_tools.set([])
@@ -1091,12 +1149,9 @@ async def _local_fallback(
                         ),
                     },
                 ]
-                reply = await chat_with_agent(
-                    agent_id,
-                    session_key,
-                    corrective_messages,
-                    on_progress,
-                    trace_context=trace_context,
+                reply = await _agent_turn(
+                    agent_id, session_key, corrective_messages, on_progress,
+                    trace_context=trace_context, model_name=_model_for_step,
                 )
                 side_effects = _collect_pending_side_effects(pending_items=pending_suggestion_messages.get())
                 failed_tools = list(current_failed_tools.get())

--- a/llm/runs.py
+++ b/llm/runs.py
@@ -212,6 +212,21 @@ def start_run(
     run_token = current_run_id.set(run_id)
     seq_token = current_run_sequence.set(itertools.count(start=0))
     handle_token = _current_run_handle.set(handle)
+    # ATIF step_id is 1-indexed per spec — distinct from the legacy
+    # 0-indexed sequence_num used by the in-flight log_trace shim.
+    from llm.trajectory import (
+        init_run_step_counter, record_step, reset_run_step_counter,
+    )
+    step_token = init_run_step_counter()
+
+    # ATIF Step 1 = the user's trigger input. Recording at run start
+    # gives every trajectory a deterministic first step regardless of
+    # whether the loop produces any agent steps (e.g. fast-path errors).
+    if trigger_input:
+        try:
+            record_step("user", trigger_input)
+        except Exception:
+            logger.exception("failed to record initial user step run_id=%s", run_id)
     raised: BaseException | None = None
     try:
         yield handle
@@ -222,6 +237,7 @@ def start_run(
             handle.error_message = str(exc)
         raise
     finally:
+        reset_run_step_counter(step_token)
         _current_run_handle.reset(handle_token)
         current_run_sequence.reset(seq_token)
         current_run_id.reset(run_token)

--- a/llm/tests/test_trajectory.py
+++ b/llm/tests/test_trajectory.py
@@ -1,0 +1,234 @@
+"""Tests for ``llm/trajectory.py`` — ATIF v1.4 step writers + serializer."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from backends.local_auth import (
+    reset_fallback_request_context,
+    set_fallback_request_context,
+)
+from db.models import AgentRun, AgentStep, AgentTrace
+from llm.runs import accumulate_run_totals, start_run
+from llm.trajectory import (
+    ATIF_SCHEMA_VERSION,
+    begin_agent_step,
+    record_step,
+    to_trajectory,
+)
+
+
+def _ctx():
+    return set_fallback_request_context(account_id=1, org_id=1)
+
+
+def test_to_trajectory_emits_atif_v14_envelope(db):
+    """A run with one user step + one agent step renders the canonical
+    ATIF v1.4 envelope: schema_version, session_id, agent block, ordered
+    steps[], and final_metrics with total_cost_usd in dollars."""
+    token = _ctx()
+    try:
+        with start_run(
+            source="chat",
+            agent_version="rentmate-test",
+            execution_path="local",
+            model="claude-haiku-4-5",
+            trigger_input="hello",
+        ) as run:
+            with begin_agent_step("hi back", model_name="claude-haiku-4-5") as step:
+                # Simulate a litellm call that bumped the run handle.
+                accumulate_run_totals(input_tokens=100, output_tokens=50, iteration_count=1)
+                if step is not None:
+                    step.add_tool_call(
+                        tool_call_id="call_1",
+                        function_name="lookup_vendors",
+                        arguments={"vendor_type": "plumber"},
+                    )
+                    step.add_observation(
+                        source_call_id="call_1",
+                        content="Found 3 vendors.",
+                    )
+            run.complete(status="completed", final_response="hi back")
+        run_id = run.run_id
+    finally:
+        reset_fallback_request_context(token)
+
+    traj = to_trajectory(db, run_id)
+    assert traj is not None
+    assert traj["schema_version"] == ATIF_SCHEMA_VERSION
+    assert traj["session_id"] == run_id
+    assert traj["agent"]["model_name"] == "claude-haiku-4-5"
+
+    steps = traj["steps"]
+    assert [s["step_id"] for s in steps] == [1, 2]
+    assert steps[0]["source"] == "user"
+    assert steps[0]["message"] == "hello"
+    assert steps[1]["source"] == "agent"
+    assert steps[1]["message"] == "hi back"
+    assert steps[1]["tool_calls"][0]["function_name"] == "lookup_vendors"
+    assert steps[1]["observation"]["results"][0]["content"] == "Found 3 vendors."
+
+    fm = traj["final_metrics"]
+    assert fm["total_prompt_tokens"] == 100
+    assert fm["total_completion_tokens"] == 50
+    assert fm["total_steps"] == 2
+    # cost_usd is cents/100 — _compute_cost_cents for haiku at 100/Mtok
+    # input + 500/Mtok output = (100*100 + 50*500)/1M = 0.035 cents
+    # → 0.00035 USD.
+    assert fm["total_cost_usd"] == 0.00035
+
+
+def test_step_builder_collapses_tool_calls_into_one_step(db):
+    """Multiple tools fired inside one ``begin_agent_step`` collapse
+    into a single AgentStep with all tool_calls and observation results,
+    matching ATIF's per-turn model."""
+    token = _ctx()
+    try:
+        with start_run(
+            source="chat",
+            agent_version="rentmate-test",
+            execution_path="local",
+            trigger_input="trigger",
+        ) as run:
+            with begin_agent_step("done", model_name="m") as step:
+                if step is not None:
+                    step.add_tool_call(tool_call_id="a", function_name="t1", arguments={})
+                    step.add_observation(source_call_id="a", content="r1")
+                    step.add_tool_call(tool_call_id="b", function_name="t2", arguments={})
+                    step.add_observation(source_call_id="b", content="r2")
+        run_id = run.run_id
+    finally:
+        reset_fallback_request_context(token)
+
+    rows = db.query(AgentStep).filter_by(run_id=run_id).order_by(AgentStep.step_id).all()
+    # step_id=1 (user) + step_id=2 (agent with both tools).
+    assert [r.step_id for r in rows] == [1, 2]
+    agent_step = rows[1]
+    assert [tc["function_name"] for tc in agent_step.tool_calls] == ["t1", "t2"]
+    assert [r["content"] for r in agent_step.observation["results"]] == ["r1", "r2"]
+
+
+def test_step_builder_records_tool_error_in_observation(db):
+    """Tool errors land in observation.results as ``ERROR: …`` content
+    plus ``extra.error_kind="tool_error"`` so analytics can flag failed
+    turns without parsing free-text messages."""
+    token = _ctx()
+    try:
+        with start_run(
+            source="chat",
+            agent_version="rentmate-test",
+            execution_path="local",
+            trigger_input="t",
+        ) as run:
+            with begin_agent_step("oops", model_name="m") as step:
+                if step is not None:
+                    step.add_tool_call(tool_call_id="x", function_name="boom", arguments={})
+                    step.add_observation(source_call_id="x", content="ERROR: vendor 500")
+                    step.add_extra("error_kind", "tool_error")
+        run_id = run.run_id
+    finally:
+        reset_fallback_request_context(token)
+
+    agent_step = (
+        db.query(AgentStep)
+        .filter_by(run_id=run_id, source="agent")
+        .one()
+    )
+    assert agent_step.observation["results"][0]["content"].startswith("ERROR: ")
+    assert agent_step.extra["error_kind"] == "tool_error"
+
+
+def test_cost_usd_emitted_as_cents_div_100(db):
+    """The serializer divides ``total_cost_cents`` (Numeric 10,4) by 100
+    so ATIF gets ``total_cost_usd`` in dollars, not cents."""
+    token = _ctx()
+    try:
+        with start_run(
+            source="chat",
+            agent_version="rentmate-test",
+            execution_path="local",
+            trigger_input="t",
+        ) as run:
+            run.total_cost_cents = Decimal("1.2345")  # 1.2345 cents = $0.012345
+        run_id = run.run_id
+    finally:
+        reset_fallback_request_context(token)
+
+    # Bypass the start_run finalizer's cost computation by writing direct.
+    row = db.query(AgentRun).filter_by(id=run_id).one()
+    row.total_cost_cents = Decimal("1.2345")
+    db.flush()
+
+    traj = to_trajectory(db, run_id)
+    assert traj is not None
+    assert traj["final_metrics"]["total_cost_usd"] == 0.012345
+
+
+def test_legacy_adapter_groups_tool_call_and_result_traces(db):
+    """A pre-cutover run with only ``agent_traces`` rows renders a valid
+    ATIF trajectory via the legacy adapter — tool_call + tool_result
+    traces collapse into a single agent step's tool_calls + observation."""
+    token = _ctx()
+    try:
+        # Don't open a step builder — write traces directly to mimic an
+        # old run created before this rewrite.
+        from llm.tracing import log_trace, make_trace_envelope
+        with start_run(
+            source="chat",
+            agent_version="rentmate-test",
+            execution_path="local",
+            trigger_input="legacy run",
+        ) as run:
+            run_id = run.run_id
+            log_trace(
+                "tool_call", "chat", "lookup_vendors",
+                tool_name="lookup_vendors",
+                detail=make_trace_envelope("tool_call", tool_name="lookup_vendors", args={"q": "plumber"}),
+            )
+            log_trace(
+                "tool_result", "chat", "lookup_vendors completed",
+                tool_name="lookup_vendors",
+                detail=make_trace_envelope("tool_result", tool_name="lookup_vendors", result="3 vendors"),
+            )
+    finally:
+        reset_fallback_request_context(token)
+
+    # Wipe the auto-generated user step from start_run so we exercise the
+    # legacy-only path. Also wipe nothing else — agent_traces stays.
+    db.query(AgentStep).filter_by(run_id=run_id).delete()
+    db.flush()
+
+    traj = to_trajectory(db, run_id)
+    assert traj is not None
+    steps = traj["steps"]
+    # Adapter emits: synthesized user step, then one agent step with
+    # both tool_call + tool_result rolled in.
+    sources = [s["source"] for s in steps]
+    assert sources == ["user", "agent"]
+    assert steps[0]["message"] == "legacy run"
+    agent = steps[1]
+    assert agent["tool_calls"][0]["function_name"] == "lookup_vendors"
+    assert agent["observation"]["results"][0]["content"] == "3 vendors"
+
+
+def test_record_step_outside_run_drops_with_warning(db, caplog):
+    """``record_step`` outside an active ``start_run`` is a best-effort
+    no-op so stray callers can't crash background tasks."""
+    import logging
+
+    from llm.trajectory import _orphan_warned
+    _orphan_warned.clear()
+    token = _ctx()
+    try:
+        with caplog.at_level(logging.WARNING, logger="llm.trajectory"):
+            assert record_step("system", "no run here") is None
+    finally:
+        reset_fallback_request_context(token)
+
+    assert any("trajectory write outside agent run" in m for m in caplog.messages)
+    assert db.query(AgentStep).filter_by(message="no run here").count() == 0
+
+
+def test_trajectory_returns_none_for_missing_run(db):
+    """Unknown run id returns ``None`` so the dev API can 404 cleanly."""
+    assert to_trajectory(db, "00000000-0000-0000-0000-000000000bad") is None

--- a/llm/trajectory.py
+++ b/llm/trajectory.py
@@ -1,0 +1,572 @@
+"""Harbor Framework ATIF v1.4 trajectory writer + serializer.
+
+Replaces the trace-row-per-event ``llm/tracing.py`` model with a
+step-row-per-turn model that maps 1:1 to the Agent Trajectory
+Interchange Format. One ``AgentStep`` row per ATIF Step; a full ATIF
+trajectory is composed at read time by ``to_trajectory(run_id)``.
+
+Spec reference: https://www.harborframework.com/docs/agents/trajectory-format
+
+Two writer entry points:
+
+- ``record_step(source, message, …)`` — one-shot for simple turns
+  (user message, system note, plain agent reply with no tool calls).
+- ``begin_agent_step(message, model_name)`` — context manager for an
+  agent turn that fans out to tool calls + observations + metrics.
+  Buffers everything in memory and commits one ``AgentStep`` row at
+  context exit.
+
+Both write inside a nested SAVEPOINT on the caller's session so a step
+insert that fails (FK violation under test isolation, etc.) rolls back
+only the savepoint and leaves the caller's transaction usable. Steps
+fire-and-forget commit the savepoint; they ride along whatever
+transaction the caller eventually completes.
+
+Outside an active ``start_run(...)``, all writes are dropped with a
+deduped warning — the same "no run, no trace" rule as ``log_trace``.
+
+# TODO(atif): a streaming/replay API (consume an ATIF trajectory and
+# reproduce the run) belongs in a separate module — see follow-up.
+"""
+from __future__ import annotations
+
+import contextlib
+import itertools
+import logging
+import uuid
+from contextvars import ContextVar
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, Iterator
+
+from backends.local_auth import resolve_account_id, resolve_org_id
+from llm.runs import current_run_id
+
+logger = logging.getLogger(__name__)
+
+ATIF_SCHEMA_VERSION = "ATIF-v1.4"
+
+_VALID_SOURCES = ("user", "agent", "system")
+
+# Per-run ATIF step_id allocator (1-indexed per ATIF spec). Distinct from
+# ``llm.runs.current_run_sequence`` which stays 0-indexed for the legacy
+# trace shim during the cutover window.
+current_step_id_counter: ContextVar["itertools.count[int] | None"] = ContextVar(
+    "current_step_id_counter", default=None
+)
+
+# Active builder for the in-flight agent turn (set by ``begin_agent_step``).
+# Tool-dispatch callbacks pull this off the context to attach tool_calls
+# + observations onto the same step row instead of fanning them out.
+_current_step_builder: ContextVar["StepBuilder | None"] = ContextVar(
+    "_current_step_builder", default=None
+)
+
+_orphan_warned: set[tuple[str, str]] = set()
+
+
+def _warn_orphan(source: str, kind: str) -> None:
+    key = (source, kind)
+    if key in _orphan_warned:
+        return
+    _orphan_warned.add(key)
+    logger.warning(
+        "trajectory write outside agent run; dropping source=%s kind=%s "
+        "(further occurrences silenced for this pair).",
+        source, kind,
+    )
+
+
+def _next_step_id() -> int | None:
+    counter = current_step_id_counter.get()
+    if counter is None:
+        return None
+    return next(counter)
+
+
+def _persist_step(
+    *,
+    run_id: str,
+    step_id: int,
+    source: str,
+    message: str,
+    model_name: str | None = None,
+    reasoning_content: str | None = None,
+    tool_calls: list[dict] | None = None,
+    observation: dict | None = None,
+    metrics: dict | None = None,
+    extra: dict | None = None,
+) -> None:
+    """Insert one ``AgentStep`` row inside a savepoint on the caller's session."""
+    try:
+        from db.models import AgentStep
+        from db.session import SessionLocal
+
+        sess = SessionLocal.session_factory()
+        sp = sess.begin_nested()
+        try:
+            sess.add(AgentStep(
+                id=str(uuid.uuid4()),
+                org_id=resolve_org_id(),
+                creator_id=resolve_account_id(),
+                run_id=run_id,
+                step_id=step_id,
+                timestamp=datetime.now(UTC),
+                source=source,
+                message=message,
+                model_name=model_name,
+                reasoning_content=reasoning_content,
+                tool_calls=tool_calls or None,
+                observation=observation or None,
+                metrics=metrics or None,
+                extra=extra or {},
+            ))
+            sess.flush()
+            sp.commit()
+            sess.commit()
+        except Exception:
+            sp.rollback()
+            sess.rollback()
+    except Exception:
+        # Best-effort — never raise into the caller.
+        pass
+
+
+def record_step(
+    source: str,
+    message: str,
+    *,
+    model_name: str | None = None,
+    reasoning_content: str | None = None,
+    tool_calls: list[dict] | None = None,
+    observation: dict | None = None,
+    metrics: dict | None = None,
+    extra: dict | None = None,
+) -> int | None:
+    """One-shot step writer. Returns the assigned ``step_id`` or ``None``
+    if dropped (no active run)."""
+    if source not in _VALID_SOURCES:
+        raise ValueError(f"source must be one of {_VALID_SOURCES}, got {source!r}")
+    run_id = current_run_id.get()
+    if run_id is None:
+        _warn_orphan(source, "record_step")
+        return None
+    step_id = _next_step_id()
+    if step_id is None:
+        _warn_orphan(source, "record_step")
+        return None
+    _persist_step(
+        run_id=run_id,
+        step_id=step_id,
+        source=source,
+        message=message,
+        model_name=model_name,
+        reasoning_content=reasoning_content,
+        tool_calls=tool_calls,
+        observation=observation,
+        metrics=metrics,
+        extra=extra,
+    )
+    return step_id
+
+
+class StepBuilder:
+    """In-memory accumulator for a single agent step.
+
+    Tool-dispatch callbacks reach for the active builder via
+    ``current_step_builder()`` and call ``add_tool_call`` /
+    ``add_observation`` on it. On context exit the buffered state is
+    flushed to one ``AgentStep`` row.
+    """
+
+    def __init__(self, *, run_id: str, step_id: int, message: str, model_name: str | None):
+        self._run_id = run_id
+        self._step_id = step_id
+        self._message = message
+        self._model_name = model_name
+        self._reasoning_content: str | None = None
+        self._tool_calls: list[dict] = []
+        self._results: list[dict] = []
+        self._metrics: dict[str, Any] | None = None
+        self._extra: dict[str, Any] = {}
+
+    @property
+    def step_id(self) -> int:
+        return self._step_id
+
+    def add_tool_call(self, *, tool_call_id: str, function_name: str, arguments: dict | None) -> None:
+        self._tool_calls.append({
+            "tool_call_id": tool_call_id,
+            "function_name": function_name,
+            "arguments": arguments or {},
+        })
+
+    def add_observation(self, *, source_call_id: str, content: str) -> None:
+        self._results.append({
+            "source_call_id": source_call_id,
+            "content": content,
+        })
+
+    def set_metrics(
+        self,
+        *,
+        prompt_tokens: int,
+        completion_tokens: int,
+        cost_usd: float,
+        cached_tokens: int | None = None,
+    ) -> None:
+        # TODO(atif): populate reasoning_content from the litellm response
+        # — needs per-provider shim (Anthropic <thinking>, OpenAI
+        # reasoning_content). For now reasoning is captured by callers
+        # that already have it via ``set_reasoning_content``.
+        metrics: dict[str, Any] = {
+            "prompt_tokens": int(prompt_tokens),
+            "completion_tokens": int(completion_tokens),
+            "cost_usd": float(cost_usd),
+        }
+        if cached_tokens is not None:
+            metrics["cached_tokens"] = int(cached_tokens)
+        self._metrics = metrics
+
+    def set_reasoning_content(self, content: str | None) -> None:
+        self._reasoning_content = content
+
+    def update_message(self, message: str) -> None:
+        """Replace the step's message text (e.g. once the final assistant
+        reply is known after the loop iteration completes)."""
+        self._message = message
+
+    def add_extra(self, key: str, value: Any) -> None:
+        self._extra[key] = value
+
+    def _commit(self) -> None:
+        observation = {"results": self._results} if self._results else None
+        _persist_step(
+            run_id=self._run_id,
+            step_id=self._step_id,
+            source="agent",
+            message=self._message,
+            model_name=self._model_name,
+            reasoning_content=self._reasoning_content,
+            tool_calls=self._tool_calls or None,
+            observation=observation,
+            metrics=self._metrics,
+            extra=self._extra,
+        )
+
+
+@contextlib.contextmanager
+def begin_agent_step(
+    message: str = "",
+    *,
+    model_name: str | None = None,
+) -> Iterator[StepBuilder | None]:
+    """Open an agent step. The returned builder accumulates tool calls,
+    observations, and metrics until context exit, then flushes one row.
+
+    On context exit the builder auto-derives ``metrics`` from the delta
+    of the run handle's running token totals — every ``litellm.acompletion``
+    inside this context bumps the handle via ``accumulate_run_totals``,
+    so the delta is the per-step token spend. ``cost_usd`` comes from
+    ``llm.runs._compute_cost_cents`` divided by 100.
+
+    Yields ``None`` outside an active run so callers can use it
+    unconditionally without crashing background paths.
+    """
+    run_id = current_run_id.get()
+    if run_id is None:
+        _warn_orphan("agent", "begin_agent_step")
+        yield None
+        return
+    step_id = _next_step_id()
+    if step_id is None:
+        _warn_orphan("agent", "begin_agent_step")
+        yield None
+        return
+
+    # Snapshot run-handle token totals so the step's metrics fall out of
+    # the delta at exit. Avoids threading per-step token plumbing through
+    # the agent loop.
+    from llm.runs import _current_run_handle, _compute_cost_cents
+    handle = _current_run_handle.get()
+    before_in = handle.input_tokens if handle is not None else 0
+    before_out = handle.output_tokens if handle is not None else 0
+
+    builder = StepBuilder(
+        run_id=run_id, step_id=step_id, message=message, model_name=model_name,
+    )
+    token = _current_step_builder.set(builder)
+    raised: BaseException | None = None
+    try:
+        yield builder
+    except BaseException as exc:
+        raised = exc
+        builder.add_extra("step_errored", True)
+        builder.add_extra("error_message", str(exc)[:500])
+        raise
+    finally:
+        _current_step_builder.reset(token)
+        if builder._metrics is None and handle is not None:
+            d_in = max(0, handle.input_tokens - before_in)
+            d_out = max(0, handle.output_tokens - before_out)
+            if d_in or d_out:
+                cost_cents = _compute_cost_cents(model_name, d_in, d_out)
+                cost_usd = float(cost_cents / Decimal("100"))
+                builder.set_metrics(
+                    prompt_tokens=d_in,
+                    completion_tokens=d_out,
+                    cost_usd=cost_usd,
+                )
+        try:
+            builder._commit()
+        except Exception:
+            logger.exception("failed to commit agent step run_id=%s step_id=%s",
+                             run_id, step_id)
+        if raised is not None:
+            pass
+
+
+def current_step_builder() -> StepBuilder | None:
+    """Active builder, or ``None`` if no agent step is open. Tool-dispatch
+    callbacks use this to attach tool_calls + observations onto the same
+    step row that owns the dispatch."""
+    return _current_step_builder.get()
+
+
+# ─── Serializer / read path ─────────────────────────────────────────────
+
+
+def _step_to_atif(step: Any) -> dict[str, Any]:
+    """Project an ``AgentStep`` row to ATIF Step shape — strips internal
+    columns (``org_id``, ``creator_id``, ``run_id``) and emits only fields
+    in the ATIF spec.
+
+    # TODO(atif): emit prompt_token_ids/completion_token_ids when we
+    # start exporting trajectories for RL training data.
+    """
+    out: dict[str, Any] = {
+        "step_id": int(step.step_id),
+        "timestamp": step.timestamp.isoformat() if step.timestamp else None,
+        "source": step.source,
+        "message": step.message or "",
+    }
+    if step.model_name is not None:
+        out["model_name"] = step.model_name
+    if step.reasoning_content is not None:
+        out["reasoning_content"] = step.reasoning_content
+    if step.tool_calls:
+        out["tool_calls"] = step.tool_calls
+    if step.observation:
+        out["observation"] = step.observation
+    if step.metrics:
+        out["metrics"] = step.metrics
+    if step.extra:
+        out["extra"] = step.extra
+    return out
+
+
+def to_trajectory(db: Any, run_id: str) -> dict[str, Any] | None:
+    """Build the canonical ATIF v1.4 trajectory for a run.
+
+    Reads from ``agent_steps`` when populated. Falls back to the legacy
+    adapter that synthesizes ATIF steps from pre-cutover ``agent_traces``
+    rows so historical runs keep rendering in DevTools without a data
+    migration.
+
+    Returns ``None`` if the run doesn't exist.
+    """
+    from db.models import AgentRun, AgentStep
+
+    run = db.query(AgentRun).filter_by(id=run_id).first()
+    if run is None:
+        return None
+
+    steps = (
+        db.query(AgentStep)
+        .filter_by(run_id=run_id)
+        .order_by(AgentStep.step_id)
+        .all()
+    )
+    if not steps:
+        atif_steps = _synthesize_steps_from_traces(db, run)
+    else:
+        atif_steps = [_step_to_atif(s) for s in steps]
+
+    cost_usd = float(
+        (run.total_cost_cents or Decimal("0")) / Decimal("100")
+    )
+    final_metrics = {
+        "total_prompt_tokens": int(run.total_input_tokens or 0),
+        "total_completion_tokens": int(run.total_output_tokens or 0),
+        "total_cost_usd": cost_usd,
+        "total_steps": len(atif_steps),
+    }
+    return {
+        "schema_version": ATIF_SCHEMA_VERSION,
+        "session_id": str(run.id),
+        "agent": {
+            "name": run.agent_version,
+            "version": run.prompt_version,
+            "model_name": run.model,
+        },
+        "steps": atif_steps,
+        "final_metrics": final_metrics,
+        "extra": {
+            "rentmate_status": run.status,
+            "rentmate_source": run.source,
+            "rentmate_conversation_id": run.conversation_id,
+            "rentmate_task_id": run.task_id,
+            "rentmate_execution_path": run.execution_path,
+        },
+    }
+
+
+# ─── Legacy adapter ────────────────────────────────────────────────────
+
+
+def _parse_detail(detail: str | None) -> dict[str, Any]:
+    if not detail:
+        return {}
+    try:
+        import json
+        parsed = json.loads(detail)
+        if isinstance(parsed, dict):
+            return parsed
+    except Exception:
+        pass
+    return {}
+
+
+def _synthesize_steps_from_traces(db: Any, run: Any) -> list[dict[str, Any]]:
+    """Render ATIF Steps from legacy ``agent_traces`` rows for a run that
+    pre-dates the trajectory cutover.
+
+    Lossy by design — we never captured ``reasoning_content`` and tool
+    call IDs are synthesized as ``legacy-<trace_id>`` so observations
+    cross-link via ``source_call_id``. ``llm_request`` / ``llm_reply``
+    traces become standalone agent steps with metrics derived from the
+    trace's recorded token counts.
+
+    # TODO(atif): remove this adapter when agent_traces is dropped.
+    """
+    from db.models import AgentTrace
+
+    traces = (
+        db.query(AgentTrace)
+        .filter_by(run_id=str(run.id))
+        .order_by(AgentTrace.sequence_num)
+        .all()
+    )
+
+    atif: list[dict[str, Any]] = []
+    next_step = itertools.count(start=1)
+
+    if run.trigger_input:
+        atif.append({
+            "step_id": next(next_step),
+            "timestamp": (run.started_at.isoformat() if run.started_at else None),
+            "source": "user",
+            "message": run.trigger_input,
+        })
+
+    pending_step: dict[str, Any] | None = None
+
+    def _flush_pending() -> None:
+        nonlocal pending_step
+        if pending_step is not None:
+            atif.append(pending_step)
+            pending_step = None
+
+    for trace in traces:
+        kind = (trace.trace_type or "").strip().lower()
+        detail = _parse_detail(trace.detail)
+        ts = trace.timestamp.isoformat() if trace.timestamp else None
+
+        if kind == "tool_call":
+            if pending_step is None:
+                pending_step = {
+                    "step_id": next(next_step),
+                    "timestamp": ts,
+                    "source": "agent",
+                    "message": trace.summary or "",
+                    "model_name": trace.model,
+                    "tool_calls": [],
+                    "observation": {"results": []},
+                    "extra": {"legacy": True},
+                }
+            pending_step["tool_calls"].append({
+                "tool_call_id": f"legacy-{trace.id}",
+                "function_name": trace.tool_name or detail.get("tool_name") or "unknown",
+                "arguments": detail.get("args") or {},
+            })
+        elif kind in ("tool_result", "tool_error", "error"):
+            if pending_step is None:
+                # Stand-alone error/result with no preceding tool_call —
+                # emit as a system note so ordering is preserved.
+                atif.append({
+                    "step_id": next(next_step),
+                    "timestamp": ts,
+                    "source": "system",
+                    "message": trace.summary or kind,
+                    "extra": {"legacy": True, "trace_type": kind},
+                })
+                continue
+            calls = pending_step.get("tool_calls") or []
+            source_call_id = (
+                calls[-1]["tool_call_id"] if calls else f"legacy-{trace.id}"
+            )
+            content = detail.get("result") or detail.get("error") or trace.summary or ""
+            if isinstance(content, (dict, list)):
+                import json
+                content = json.dumps(content, default=str)
+            if kind in ("tool_error", "error"):
+                content = f"ERROR: {content}"
+                pending_step.setdefault("extra", {})["error_kind"] = "tool_error"
+            pending_step["observation"]["results"].append({
+                "source_call_id": source_call_id,
+                "content": str(content),
+            })
+        elif kind in ("llm_request", "llm_reply", "llm_exchange"):
+            _flush_pending()
+            metrics: dict[str, Any] | None = None
+            if trace.input_tokens is not None or trace.output_tokens is not None:
+                metrics = {
+                    "prompt_tokens": int(trace.input_tokens or 0),
+                    "completion_tokens": int(trace.output_tokens or 0),
+                    "cost_usd": 0.0,
+                }
+            atif.append({
+                "step_id": next(next_step),
+                "timestamp": ts,
+                "source": "agent",
+                "message": trace.summary or "",
+                "model_name": trace.model,
+                **({"metrics": metrics} if metrics else {}),
+                "extra": {"legacy": True, "trace_type": kind},
+            })
+        else:
+            _flush_pending()
+            atif.append({
+                "step_id": next(next_step),
+                "timestamp": ts,
+                "source": "system",
+                "message": trace.summary or kind,
+                "extra": {"legacy": True, "trace_type": kind},
+            })
+
+    _flush_pending()
+    return atif
+
+
+# ─── Run-lifecycle integration helpers ─────────────────────────────────
+
+
+def init_run_step_counter() -> Any:
+    """Initialize the per-run ATIF step counter (1-indexed). Returned
+    token must be passed to ``reset_run_step_counter`` at run exit. Wired
+    into ``llm/runs.py:start_run``."""
+    return current_step_id_counter.set(itertools.count(start=1))
+
+
+def reset_run_step_counter(token: Any) -> None:
+    current_step_id_counter.reset(token)

--- a/www/rentmate-ui/src/pages/DevTools.runs-panel.test.tsx
+++ b/www/rentmate-ui/src/pages/DevTools.runs-panel.test.tsx
@@ -36,7 +36,8 @@ const RUNS = [
     trigger_input: 'review the task',
     final_response: null,
     error_message: 'plumber tool blew up',
-    trace_count: 1,
+    step_count: 2,
+    trace_count: 0,
   },
   {
     id: 'run-older',
@@ -57,26 +58,63 @@ const RUNS = [
     trigger_input: 'find me the lease',
     final_response: 'Here it is.',
     error_message: null,
+    // Legacy run — no AgentSteps yet, only AgentTrace rows. The
+    // server's legacy adapter still synthesizes ATIF steps on read,
+    // so the UI uses the same per-step rendering for both.
+    step_count: 0,
     trace_count: 5,
   },
 ];
 
-const TRACES_FOR_NEWER = [
-  {
-    id: 'trace-newer-0',
-    timestamp: '2026-04-25T12:00:00.100Z',
-    trace_type: 'tool_call',
-    source: 'task_review',
-    run_id: 'run-newer',
-    sequence_num: 0,
-    task_id: '42',
-    conversation_id: null,
-    tool_name: 'lookup_vendors',
-    summary: 'Looking up vendors',
-    detail: null,
-    suggestion_id: null,
+const TRAJECTORY_NEWER = {
+  schema_version: 'ATIF-v1.4',
+  session_id: 'run-newer',
+  agent: {
+    name: 'rentmate-test',
+    version: null,
+    model_name: 'anthropic/claude-sonnet-4-6',
   },
-];
+  steps: [
+    {
+      step_id: 1,
+      timestamp: '2026-04-25T12:00:00.050Z',
+      source: 'user',
+      message: 'review the task',
+    },
+    {
+      step_id: 2,
+      timestamp: '2026-04-25T12:00:00.100Z',
+      source: 'agent',
+      message: 'Looking up vendors then booking the plumber.',
+      model_name: 'anthropic/claude-sonnet-4-6',
+      tool_calls: [
+        {
+          tool_call_id: 'call_lookup_1',
+          function_name: 'lookup_vendors',
+          arguments: { vendor_type: 'plumber' },
+        },
+      ],
+      observation: {
+        results: [
+          { source_call_id: 'call_lookup_1', content: 'ERROR: vendor api 500' },
+        ],
+      },
+      metrics: {
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        cost_usd: 0.00045,
+      },
+      extra: { error_kind: 'tool_error' },
+    },
+  ],
+  final_metrics: {
+    total_prompt_tokens: 100,
+    total_completion_tokens: 50,
+    total_cost_usd: 0.00045,
+    total_steps: 2,
+  },
+  extra: { rentmate_status: 'errored' },
+};
 
 function buildResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
@@ -86,17 +124,18 @@ describe('DevTools RunsPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authFetchMock.mockImplementation(async (input: string) => {
-      if (input.startsWith('/dev/runs')) return buildResponse(RUNS);
+      if (input.startsWith('/dev/runs/run-newer/trajectory')) return buildResponse(TRAJECTORY_NEWER);
+      if (input.startsWith('/dev/runs?')) return buildResponse(RUNS);
+      if (input.startsWith('/dev/runs/')) return buildResponse({ schema_version: 'ATIF-v1.4', session_id: 'x', agent: {}, steps: [], final_metrics: { total_prompt_tokens: 0, total_completion_tokens: 0, total_cost_usd: 0, total_steps: 0 } });
       if (input.startsWith('/dev/trace-filters/tasks')) return buildResponse([]);
       if (input.startsWith('/dev/trace-filters/chats')) return buildResponse([]);
-      if (input.startsWith('/dev/traces?run_id=run-newer')) return buildResponse(TRACES_FOR_NEWER);
       if (input.startsWith('/dev/memory-items')) return buildResponse([]);
       if (input.startsWith('/dev/traces')) return buildResponse([]);
       return buildResponse({});
     });
   });
 
-  it('renders runs newest-first with status, source, totals and trace count', async () => {
+  it('renders runs newest-first with status, source, totals, and step/trace counts', async () => {
     render(
       <MemoryRouter>
         <DevTools />
@@ -105,7 +144,6 @@ describe('DevTools RunsPanel', () => {
 
     await waitFor(() => expect(screen.getByText('Agent Runs')).toBeInTheDocument());
 
-    // Both runs render.
     await waitFor(() => {
       expect(screen.getByLabelText('Toggle run run-newer')).toBeInTheDocument();
       expect(screen.getByLabelText('Toggle run run-older')).toBeInTheDocument();
@@ -115,17 +153,17 @@ describe('DevTools RunsPanel', () => {
     expect(within(newerRow).getByText('errored')).toBeInTheDocument();
     expect(within(newerRow).getByText('task_review')).toBeInTheDocument();
     expect(within(newerRow).getByText('100→50')).toBeInTheDocument();
-    expect(within(newerRow).getByText('1 traces')).toBeInTheDocument();
-    // Error message preview is shown on the row.
+    // Post-cutover run — shows step count (not trace count).
+    expect(within(newerRow).getByText('2 steps')).toBeInTheDocument();
     expect(within(newerRow).getByText('plumber tool blew up')).toBeInTheDocument();
 
+    // Pre-cutover run with no AgentSteps — falls back to trace count.
     const olderRow = screen.getByLabelText('Toggle run run-older');
     expect(within(olderRow).getByText('completed')).toBeInTheDocument();
     expect(within(olderRow).getByText('5 traces')).toBeInTheDocument();
-    expect(within(olderRow).getByText('200→80')).toBeInTheDocument();
   });
 
-  it('lazy-fetches traces for a run on expand', async () => {
+  it('lazy-fetches the ATIF trajectory on expand and renders steps inline', async () => {
     render(
       <MemoryRouter>
         <DevTools />
@@ -133,59 +171,22 @@ describe('DevTools RunsPanel', () => {
     );
 
     const toggle = await screen.findByLabelText('Toggle run run-newer');
-
-    // Before expand: no per-run trace fetch was issued.
-    expect(authFetchMock.mock.calls.some(call => String(call[0]).startsWith('/dev/traces?run_id=run-newer'))).toBe(false);
+    expect(authFetchMock.mock.calls.some(call => String(call[0]).startsWith('/dev/runs/run-newer/trajectory'))).toBe(false);
 
     fireEvent.click(toggle);
 
     await waitFor(() => {
-      expect(authFetchMock.mock.calls.some(call => String(call[0]).startsWith('/dev/traces?run_id=run-newer'))).toBe(true);
+      expect(authFetchMock.mock.calls.some(call => String(call[0]).startsWith('/dev/runs/run-newer/trajectory'))).toBe(true);
     });
 
-    // The trace shows up nested under the run row.
+    // The expanded view shows a row per ATIF step with source badges.
     await waitFor(() => {
-      expect(screen.getByText('Looking up vendors')).toBeInTheDocument();
-      expect(screen.getByText('lookup_vendors')).toBeInTheDocument();
+      expect(screen.getByText('user')).toBeInTheDocument();
+      expect(screen.getByText('agent')).toBeInTheDocument();
+      // Errored agent step is flagged inline.
+      expect(screen.getByText('error')).toBeInTheDocument();
+      // Tool count badge.
+      expect(screen.getByText('1 tool')).toBeInTheDocument();
     });
-  });
-
-  it('per-run copy button copies the run header + every trace, fetching them when needed', async () => {
-    const writeText = vi.fn(async () => {});
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    });
-
-    render(
-      <MemoryRouter>
-        <DevTools />
-      </MemoryRouter>,
-    );
-
-    const copyButton = await screen.findByLabelText('Copy run run-newer');
-
-    // Pre-condition: the run hasn't been expanded yet, so no traces fetched.
-    expect(authFetchMock.mock.calls.some(call => String(call[0]).startsWith('/dev/traces?run_id=run-newer'))).toBe(false);
-
-    fireEvent.click(copyButton);
-
-    // The copy click should NOT toggle the row expanded state.
-    const toggle = screen.getByLabelText('Toggle run run-newer');
-    expect(toggle.getAttribute('aria-expanded')).toBe('false');
-
-    // It should fetch the run's traces (lazy load) and write to clipboard.
-    await waitFor(() => {
-      expect(authFetchMock.mock.calls.some(call => String(call[0]).startsWith('/dev/traces?run_id=run-newer'))).toBe(true);
-    });
-    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
-
-    const copied = String(writeText.mock.calls[0][0]);
-    expect(copied).toContain('Run run-newer');
-    expect(copied).toContain('errored');
-    expect(copied).toContain('plumber tool blew up');
-    // Each trace appears as an indented line under the run header.
-    expect(copied).toContain('Looking up vendors');
-    expect(copied).toContain('tool_call');
   });
 });

--- a/www/rentmate-ui/src/pages/DevTools.tsx
+++ b/www/rentmate-ui/src/pages/DevTools.tsx
@@ -59,6 +59,9 @@ interface RunEntry {
   final_response: string | null;
   error_message: string | null;
   trace_count: number;
+  // ATIF Step rows for post-cutover runs. Legacy runs (pre-cutover) only
+  // have ``trace_count``; when ``step_count > 0`` we show steps instead.
+  step_count: number;
 }
 
 interface TraceFilterOption {
@@ -496,7 +499,16 @@ function RunsPanel() {
                     {run.conversation_id && (
                       <Badge variant="outline" className="text-[9px] h-4 px-1.5 shrink-0">chat</Badge>
                     )}
-                    <span className="text-[10px] text-muted-foreground shrink-0">{run.trace_count} traces</span>
+                    {/* TODO(atif): replace the trace-table view with a
+                        per-step ATIF viewer that hits
+                        /dev/runs/{id}/trajectory and renders steps,
+                        tool_calls, and observations natively. The count
+                        below is the only post-cutover surface for now. */}
+                    <span className="text-[10px] text-muted-foreground shrink-0">
+                      {run.step_count > 0
+                        ? `${run.step_count} steps`
+                        : `${run.trace_count} traces`}
+                    </span>
                   </div>
                   {(run.trigger_input || run.error_message) && (
                     <div className="mt-1 ml-5 text-xs text-muted-foreground truncate">

--- a/www/rentmate-ui/src/pages/DevTools.tsx
+++ b/www/rentmate-ui/src/pages/DevTools.tsx
@@ -64,6 +64,61 @@ interface RunEntry {
   step_count: number;
 }
 
+// Harbor ATIF v1.4 Step shape returned by /dev/runs/{id}/trajectory.
+interface AtifToolCall {
+  tool_call_id: string;
+  function_name: string;
+  arguments: Record<string, unknown>;
+}
+
+interface AtifObservationResult {
+  source_call_id: string;
+  content: string;
+}
+
+interface AtifStep {
+  step_id: number;
+  timestamp: string | null;
+  source: 'user' | 'agent' | 'system';
+  message: string;
+  model_name?: string | null;
+  reasoning_content?: string | null;
+  tool_calls?: AtifToolCall[];
+  observation?: { results: AtifObservationResult[] };
+  metrics?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    cached_tokens?: number;
+    cost_usd?: number;
+  };
+  extra?: Record<string, unknown>;
+}
+
+interface AtifTrajectory {
+  schema_version: string;
+  session_id: string;
+  agent: {
+    name: string;
+    version: string | null;
+    model_name: string | null;
+  };
+  steps: AtifStep[];
+  final_metrics: {
+    total_prompt_tokens: number;
+    total_completion_tokens: number;
+    total_cached_tokens?: number;
+    total_cost_usd: number;
+    total_steps: number;
+  };
+  extra?: Record<string, unknown>;
+}
+
+const STEP_SOURCE_COLORS: Record<AtifStep['source'], string> = {
+  user: 'bg-slate-100 text-slate-800',
+  agent: 'bg-purple-100 text-purple-800',
+  system: 'bg-amber-100 text-amber-800',
+};
+
 interface TraceFilterOption {
   id: string;
   raw_id?: string;
@@ -139,6 +194,12 @@ function RunsPanel() {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [tracesByRun, setTracesByRun] = useState<Map<string, TraceEntry[]>>(new Map());
   const [traceLoading, setTraceLoading] = useState<Set<string>>(new Set());
+  // ATIF trajectory cache. Always populated for expanded runs (the
+  // legacy adapter on the server synthesizes ATIF steps from
+  // pre-cutover trace rows so the UI has a single rendering path).
+  const [trajectoryByRun, setTrajectoryByRun] = useState<Map<string, AtifTrajectory>>(new Map());
+  const [trajectoryLoading, setTrajectoryLoading] = useState<Set<string>>(new Set());
+  const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
   const [selectedTrace, setSelectedTrace] = useState<TraceDetailEntry | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailSection, setDetailSection] = useState<'overview' | 'context' | 'retrieval' | 'io' | 'reasoning' | 'raw'>('overview');
@@ -186,6 +247,31 @@ function RunsPanel() {
     }
   }, []);
 
+  const loadTrajectoryForRun = useCallback(async (runId: string) => {
+    setTrajectoryLoading(prev => {
+      const next = new Set(prev);
+      next.add(runId);
+      return next;
+    });
+    try {
+      const res = await authFetch(`/dev/runs/${encodeURIComponent(runId)}/trajectory`);
+      if (res.ok) {
+        const data = (await res.json()) as AtifTrajectory;
+        setTrajectoryByRun(prev => {
+          const next = new Map(prev);
+          next.set(runId, data);
+          return next;
+        });
+      }
+    } catch { /* ignore */ } finally {
+      setTrajectoryLoading(prev => {
+        const next = new Set(prev);
+        next.delete(runId);
+        return next;
+      });
+    }
+  }, []);
+
   useEffect(() => { loadRuns(); }, [loadRuns]);
 
   useEffect(() => {
@@ -204,14 +290,19 @@ function RunsPanel() {
     void loadFilters();
   }, []);
 
-  // Auto-refresh every 5s — re-fetch the run list AND any expanded run's traces
+  // Auto-refresh every 5s — re-fetch the run list AND any expanded
+  // run's trajectory (or legacy traces, for the run-detail dialog
+  // path).
   useEffect(() => {
     const id = setInterval(() => {
       void loadRuns();
-      expanded.forEach(runId => void loadTracesForRun(runId));
+      expanded.forEach(runId => {
+        void loadTrajectoryForRun(runId);
+        if (tracesByRun.has(runId)) void loadTracesForRun(runId);
+      });
     }, 5000);
     return () => clearInterval(id);
-  }, [loadRuns, loadTracesForRun, expanded]);
+  }, [loadRuns, loadTracesForRun, loadTrajectoryForRun, expanded, tracesByRun]);
 
   const toggleRun = (runId: string) => {
     setExpanded(prev => {
@@ -220,10 +311,19 @@ function RunsPanel() {
         next.delete(runId);
       } else {
         next.add(runId);
-        if (!tracesByRun.has(runId)) {
-          void loadTracesForRun(runId);
+        if (!trajectoryByRun.has(runId)) {
+          void loadTrajectoryForRun(runId);
         }
       }
+      return next;
+    });
+  };
+
+  const toggleStep = (key: string) => {
+    setExpandedSteps(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
       return next;
     });
   };
@@ -463,8 +563,8 @@ function RunsPanel() {
         )}
         {runs.map(run => {
           const isExpanded = expanded.has(run.id);
-          const traces = tracesByRun.get(run.id);
-          const isLoadingTraces = traceLoading.has(run.id);
+          const trajectory = trajectoryByRun.get(run.id);
+          const isLoadingTrajectory = trajectoryLoading.has(run.id);
           return (
             <div key={run.id} className="border rounded-lg">
               <div className="flex items-start gap-1 px-1 py-1">
@@ -499,11 +599,6 @@ function RunsPanel() {
                     {run.conversation_id && (
                       <Badge variant="outline" className="text-[9px] h-4 px-1.5 shrink-0">chat</Badge>
                     )}
-                    {/* TODO(atif): replace the trace-table view with a
-                        per-step ATIF viewer that hits
-                        /dev/runs/{id}/trajectory and renders steps,
-                        tool_calls, and observations natively. The count
-                        below is the only post-cutover surface for now. */}
                     <span className="text-[10px] text-muted-foreground shrink-0">
                       {run.step_count > 0
                         ? `${run.step_count} steps`
@@ -534,46 +629,177 @@ function RunsPanel() {
 
               {isExpanded && (
                 <div className="border-t bg-muted/20 px-1 py-1 space-y-1">
-                  {isLoadingTraces && !traces && (
-                    <p className="text-[10px] text-muted-foreground text-center py-2">Loading traces…</p>
+                  {isLoadingTrajectory && !trajectory && (
+                    <p className="text-[10px] text-muted-foreground text-center py-2">Loading trajectory…</p>
                   )}
-                  {traces && traces.length === 0 && (
-                    <p className="text-[10px] text-muted-foreground text-center py-2">No traces for this run.</p>
+                  {trajectory && trajectory.steps.length === 0 && (
+                    <p className="text-[10px] text-muted-foreground text-center py-2">No steps recorded for this run.</p>
                   )}
-                  {traces?.map(t => (
-                    <div key={t.id} className="flex items-center gap-1 px-1 py-0.5">
-                      <button
-                        className="min-w-0 flex-1 text-left px-2 py-1 flex items-center gap-2 hover:bg-background transition-colors rounded-md"
-                        onClick={() => void openTrace(t.id)}
-                      >
-                        <span className="text-[10px] text-muted-foreground font-mono w-8 shrink-0">
-                          #{t.sequence_num ?? '?'}
-                        </span>
-                        <span className="text-[10px] text-muted-foreground font-mono w-16 shrink-0">
-                          {formatTime(t.timestamp)}
-                        </span>
-                        <Badge className={cn("text-[9px] h-4 px-1.5 shrink-0", TRACE_COLORS[t.trace_type] ?? 'bg-gray-100 text-gray-700')}>
-                          {t.trace_type}
-                        </Badge>
-                        {t.tool_name && (
-                          <Badge variant="outline" className="text-[9px] h-4 px-1.5 shrink-0">{t.tool_name}</Badge>
+                  {trajectory?.steps.map(step => {
+                    const stepKey = `${run.id}:${step.step_id}`;
+                    const stepExpanded = expandedSteps.has(stepKey);
+                    const toolCount = step.tool_calls?.length ?? 0;
+                    const obsCount = step.observation?.results?.length ?? 0;
+                    const errored = (step.extra as Record<string, unknown> | undefined)?.error_kind === 'tool_error'
+                      || (step.extra as Record<string, unknown> | undefined)?.step_errored === true;
+                    const messageOneLine = (step.message || '').split('\n', 1)[0] || '(no message)';
+                    return (
+                      <div key={stepKey} className="border rounded-md bg-background/40">
+                        <button
+                          type="button"
+                          className="w-full text-left px-2 py-1 flex items-center gap-2 hover:bg-background transition-colors rounded-md"
+                          onClick={() => toggleStep(stepKey)}
+                          aria-expanded={stepExpanded}
+                        >
+                          {stepExpanded
+                            ? <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />
+                            : <ChevronRight className="h-3 w-3 text-muted-foreground shrink-0" />}
+                          <span className="text-[10px] text-muted-foreground font-mono w-8 shrink-0">
+                            #{step.step_id}
+                          </span>
+                          <span className="text-[10px] text-muted-foreground font-mono w-16 shrink-0">
+                            {step.timestamp ? formatTime(step.timestamp) : ''}
+                          </span>
+                          <Badge className={cn(
+                            'text-[9px] h-4 px-1.5 shrink-0',
+                            STEP_SOURCE_COLORS[step.source] ?? 'bg-gray-100 text-gray-700',
+                          )}>
+                            {step.source}
+                          </Badge>
+                          {step.model_name && (
+                            <Badge variant="outline" className="text-[9px] h-4 px-1.5 shrink-0">
+                              {shortModel(step.model_name)}
+                            </Badge>
+                          )}
+                          {toolCount > 0 && (
+                            <Badge variant="outline" className="text-[9px] h-4 px-1.5 shrink-0">
+                              {toolCount} tool{toolCount === 1 ? '' : 's'}
+                            </Badge>
+                          )}
+                          {errored && (
+                            <Badge className="text-[9px] h-4 px-1.5 shrink-0 bg-red-100 text-red-800">
+                              error
+                            </Badge>
+                          )}
+                          <span className="text-xs truncate flex-1">{messageOneLine}</span>
+                          {step.metrics?.cost_usd !== undefined && step.metrics.cost_usd > 0 && (
+                            <span className="text-[10px] text-muted-foreground font-mono shrink-0">
+                              ${step.metrics.cost_usd.toFixed(4)}
+                            </span>
+                          )}
+                          {step.metrics && (
+                            <span className="text-[10px] text-muted-foreground font-mono shrink-0">
+                              {step.metrics.prompt_tokens ?? 0}→{step.metrics.completion_tokens ?? 0}
+                            </span>
+                          )}
+                        </button>
+                        {stepExpanded && (
+                          <div className="border-t px-3 py-2 space-y-2 text-xs">
+                            {step.message && (
+                              <div>
+                                <div className="text-[10px] uppercase tracking-wide text-muted-foreground mb-1">
+                                  Message
+                                </div>
+                                <pre className="bg-muted/40 rounded p-2 whitespace-pre-wrap font-mono text-[11px]">
+                                  {step.message}
+                                </pre>
+                              </div>
+                            )}
+                            {step.reasoning_content && (
+                              <div>
+                                <div className="text-[10px] uppercase tracking-wide text-muted-foreground mb-1">
+                                  Reasoning
+                                </div>
+                                <pre className="bg-muted/40 rounded p-2 whitespace-pre-wrap font-mono text-[11px]">
+                                  {step.reasoning_content}
+                                </pre>
+                              </div>
+                            )}
+                            {step.tool_calls?.map(tc => {
+                              // Pair each tool call with its observation result by source_call_id.
+                              const result = step.observation?.results.find(
+                                r => r.source_call_id === tc.tool_call_id,
+                              );
+                              const isError = result?.content?.startsWith('ERROR:');
+                              return (
+                                <div key={tc.tool_call_id} className="border rounded">
+                                  <div className="px-2 py-1 flex items-center gap-2 bg-muted/30">
+                                    <Badge variant="outline" className="text-[9px] h-4 px-1.5">
+                                      {tc.function_name}
+                                    </Badge>
+                                    <span className="text-[10px] text-muted-foreground font-mono truncate">
+                                      {tc.tool_call_id}
+                                    </span>
+                                    {isError && (
+                                      <Badge className="text-[9px] h-4 px-1.5 bg-red-100 text-red-800">
+                                        error
+                                      </Badge>
+                                    )}
+                                  </div>
+                                  <div className="px-2 py-1 grid grid-cols-1 md:grid-cols-2 gap-2">
+                                    <div>
+                                      <div className="text-[10px] uppercase tracking-wide text-muted-foreground mb-1">
+                                        Arguments
+                                      </div>
+                                      <pre className="bg-muted/40 rounded p-1.5 whitespace-pre-wrap font-mono text-[10px]">
+                                        {JSON.stringify(tc.arguments, null, 2)}
+                                      </pre>
+                                    </div>
+                                    <div>
+                                      <div className="text-[10px] uppercase tracking-wide text-muted-foreground mb-1">
+                                        Observation
+                                      </div>
+                                      <pre className={cn(
+                                        'rounded p-1.5 whitespace-pre-wrap font-mono text-[10px]',
+                                        isError ? 'bg-red-50 text-red-800' : 'bg-muted/40',
+                                      )}>
+                                        {result?.content ?? '(no result)'}
+                                      </pre>
+                                    </div>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                            {/* Observations without a matching tool_call (rare but possible from the legacy adapter). */}
+                            {(step.observation?.results ?? [])
+                              .filter(r => !(step.tool_calls ?? []).some(tc => tc.tool_call_id === r.source_call_id))
+                              .map(r => (
+                                <div key={r.source_call_id} className="border rounded">
+                                  <div className="px-2 py-1 bg-muted/30 text-[10px] text-muted-foreground font-mono">
+                                    {r.source_call_id}
+                                  </div>
+                                  <pre className="px-2 py-1 whitespace-pre-wrap font-mono text-[10px]">
+                                    {r.content}
+                                  </pre>
+                                </div>
+                              ))}
+                            {step.metrics && (
+                              <div className="text-[10px] text-muted-foreground">
+                                tokens: {step.metrics.prompt_tokens ?? 0} prompt /
+                                {' '}{step.metrics.completion_tokens ?? 0} completion
+                                {step.metrics.cached_tokens
+                                  ? ` / ${step.metrics.cached_tokens} cached`
+                                  : ''}
+                                {step.metrics.cost_usd
+                                  ? ` · cost $${step.metrics.cost_usd.toFixed(6)}`
+                                  : ''}
+                              </div>
+                            )}
+                            {step.extra && Object.keys(step.extra).length > 0 && (
+                              <details className="text-[10px]">
+                                <summary className="cursor-pointer text-muted-foreground">
+                                  extra
+                                </summary>
+                                <pre className="mt-1 bg-muted/40 rounded p-2 whitespace-pre-wrap font-mono">
+                                  {JSON.stringify(step.extra, null, 2)}
+                                </pre>
+                              </details>
+                            )}
+                          </div>
                         )}
-                        <span className="text-xs truncate flex-1">{t.summary}</span>
-                      </button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 w-6 shrink-0 p-0"
-                        aria-label={`Copy trace ${t.id}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          copyTrace(t);
-                        }}
-                      >
-                        <Copy className="h-3 w-3" />
-                      </Button>
-                    </div>
-                  ))}
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary

Adopts [Harbor Framework's Agent Trajectory Interchange Format v1.4](https://www.harborframework.com/docs/agents/trajectory-format) for agent run persistence. Replaces the heterogeneous \`AgentTrace\` row-per-event model with a step-row-per-turn \`AgentStep\` table that maps 1:1 to ATIF Step.

- New \`agent_steps\` table — every column lines up with an ATIF Step field.
- New \`llm/trajectory.py\` — \`record_step\`, \`begin_agent_step\` (StepBuilder context manager), \`to_trajectory\` (ATIF v1.4 serializer), legacy adapter that synthesizes ATIF Steps from pre-cutover \`agent_traces\` rows on read (no data migration).
- \`start_run\` now records the trigger as step_id=1 (source=user). \`_local_fallback\` wraps each \`chat_with_agent\` call in a builder so tool calls + observations + metrics collapse into one row.
- New \`GET /dev/runs/{run_id}/trajectory\` returns ATIF JSON. \`GET /dev/runs\` listing adds a \`step_count\` aggregate.
- 7 new tests in \`llm/tests/test_trajectory.py\` cover envelope shape, tool-call collapsing, error-in-observation, cost emission, the legacy adapter, the orphan-write warning, and the 404 path.

Cost stays in cents internally and is divided by 100 for ATIF's \`cost_usd\` — keeps Numeric precision, no backfill needed. Run-level rentmate metadata (status, source, task_id, conversation_id, execution_path) ships under ATIF's top-level \`extra\` slot.

## Follow-ups (TODOs landed inline)

- Drop \`agent_traces\` table once historical replay value expires (\`db/models/agent_trace.py\`).
- Capture \`reasoning_content\` via per-provider chain-of-thought shim (\`llm/trajectory.py:StepBuilder\`).
- Emit \`prompt_token_ids\` / \`completion_token_ids\` for RL training data export.
- Replace the trace-table view in DevTools with a per-step ATIF viewer that hits \`/dev/runs/{id}/trajectory\` (\`www/rentmate-ui/src/pages/DevTools.tsx\`).
- Streaming/replay API to consume an ATIF trajectory and reproduce a run.

## Test plan

- [x] \`pytest llm/tests/test_trajectory.py\` — 7 passing
- [x] \`pytest llm/tests/test_runs.py llm/tests/test_tracing.py handlers/tests/test_dev_runs.py\` — 14 passing
- [x] Full backend (\`pytest -q --ignore=evals\`) — 673 passing (one pre-existing flake in test_chat_extra.py deselected)
- [x] Frontend \`tsc --noEmit\` clean
- [x] Frontend vitest — 78 passing
- [ ] Manual: trigger an agent flow, \`curl /dev/runs?limit=5\` shows \`step_count > 0\`, \`curl /dev/runs/<id>/trajectory\` returns valid ATIF JSON
- [x] Manual: pre-cutover run renders via legacy adapter