### PR TITLE
reply_scanner: fix NameError '_hbjson is not defined'

### DIFF
--- a/handlers/chat.py
+++ b/handlers/chat.py
@@ -755,7 +755,7 @@ def _agent_task_autoreply_inner(task_id: str, hint: str | None = None) -> str | 
         # Gather progress steps
         steps_text = ""
         if task.steps:
-            steps_text = "\n\nTask progress steps:\n" + _hbjson.dumps(task.steps, indent=2)
+            steps_text = "\n\nTask progress steps:\n" + json.dumps(task.steps, indent=2)
 
         # Build AI conversation history
         all_msgs = [


### PR DESCRIPTION
## Summary

Production trace:

\`\`\`
[reply_scanner] Failed for task 6: name '_hbjson' is not defined
  File "/app/handlers/chat.py", line 758, in _agent_task_autoreply_inner
    steps_text = "\n\nTask progress steps:\n" + _hbjson.dumps(task.steps, indent=2)
                                                ^^^^^^^
NameError: name '_hbjson' is not defined
\`\`\`

The line was meant to call \`json.dumps\` (already imported at the top of the module) but had a typo carried over from a long-ago rename. Tests didn't catch it because every fixture task has empty \`steps\` and the \`if task.steps\` guard short-circuits before the lookup. Production tripped on the first task that had any progress steps.

## Test plan

- [x] \`python -c "import handlers.chat"\` clean
- [ ] reply_scanner runs against a task with non-empty \`task.steps\` without raising