### PR TITLE
fix: collapse parallel alembic heads + reply_scanner _hbjson NameError

### DIFF
--- a/db/migrations/versions/d3f5a6b7c8d9_add_agent_steps.py
+++ b/db/migrations/versions/d3f5a6b7c8d9_add_agent_steps.py
@@ -8,7 +8,7 @@ DevTools without a data migration. A follow-up migration drops
 ``agent_traces`` once that historical replay value expires.
 
 Revision ID: d3f5a6b7c8d9
-Revises: c2f3e4d5a6b8
+Revises: c8d9e0f1a2b3
 Create Date: 2026-04-28
 """
 from typing import Sequence, Union
@@ -19,7 +19,11 @@ from sqlalchemy.dialects import postgresql
 
 
 revision: str = "d3f5a6b7c8d9"
-down_revision: Union[str, None] = "c2f3e4d5a6b8"
+# Originally chained to ``c2f3e4d5a6b8``; PR #51 (multi-tenant leases)
+# landed on main first with its own descendant ``c8d9e0f1a2b3``, which
+# left main with two parallel heads after this migration also merged.
+# Rechained to ``c8d9e0f1a2b3`` so alembic sees a single head again.
+down_revision: Union[str, None] = "c8d9e0f1a2b3"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/handlers/chat.py
+++ b/handlers/chat.py
@@ -755,7 +755,7 @@ def _agent_task_autoreply_inner(task_id: str, hint: str | None = None) -> str | 
         # Gather progress steps
         steps_text = ""
         if task.steps:
-            steps_text = "\n\nTask progress steps:\n" + _hbjson.dumps(task.steps, indent=2)
+            steps_text = "\n\nTask progress steps:\n" + json.dumps(task.steps, indent=2)
 
         # Build AI conversation history
         all_msgs = [


### PR DESCRIPTION
Two small unrelated fixes batched together. Both target main.

## 1. Alembic — collapse parallel heads

PR #49 (atif-trajectory) and PR #51 (multi-tenant-leases) both descended from \`c2f3e4d5a6b8\` and merged into main back-to-back, leaving two parallel alembic heads (\`d3f5a6b7c8d9\` and \`c8d9e0f1a2b3\`). \`alembic upgrade head\` now fails with "Multiple head revisions are present".

Re-chain \`add_agent_steps\` (\`d3f5a6b7c8d9\`) to descend from \`add_lease_tenants\` (\`c8d9e0f1a2b3\`). The two migrations are independent (different tables, no shared columns), so the order is arbitrary; chained ATIF after leases since #51 merged first chronologically.

## 2. reply_scanner — fix \`NameError: '_hbjson' is not defined\`

Production trace:

\`\`\`
[reply_scanner] Failed for task 6: name '_hbjson' is not defined
  File "/app/handlers/chat.py", line 758, in _agent_task_autoreply_inner
    steps_text = "\n\nTask progress steps:\n" + _hbjson.dumps(task.steps, indent=2)
\`\`\`

The line was meant to call \`json.dumps\` (already imported at the top of the module) but had a typo carried over from a long-ago rename. Tests didn't catch it because every fixture task has empty \`steps\` and the \`if task.steps\` guard short-circuits before the lookup. Production tripped on the first task that had any progress steps.

## Test plan

- [x] \`alembic heads\` reports a single head (\`d3f5a6b7c8d9\`)
- [x] \`scripts/check_migrations.py\` runs clean — applies all migrations + reports "No new upgrade operations detected"
- [x] \`python -c "import handlers.chat"\` clean
- [ ] reply_scanner against a task with non-empty \`task.steps\` no longer raises