### PR TITLE
Mobile-friendly tabbed layout for dashboard + chats

### DIFF
--- a/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.test.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+
+import { ChatWorkspaceLayout } from './ChatWorkspaceLayout';
+
+// ChatPanel is heavy + irrelevant to layout tests — stub it.
+vi.mock('./ChatPanel', () => ({
+  ChatPanel: () => <div data-testid="embedded-chat-panel">embedded</div>,
+}));
+
+// useApp returns whatever the chatPanel mock currently is.
+let chatPanelState = {
+  isOpen: false,
+  conversationId: null as string | null,
+  taskId: null as string | null,
+  suggestionId: null as string | null,
+};
+vi.mock('@/context/AppContext', () => ({
+  useApp: () => ({
+    chatPanel: chatPanelState,
+  }),
+}));
+
+beforeEach(() => {
+  chatPanelState = { isOpen: false, conversationId: null, taskId: null, suggestionId: null };
+});
+
+function renderLayout(opts: {
+  withRightRail?: boolean;
+  mobileDefaultPane?: 'left' | 'middle' | 'right';
+} = {}) {
+  return render(
+    <ChatWorkspaceLayout
+      leftRail={<div data-testid="left-rail-content">left rail</div>}
+      rightRail={opts.withRightRail
+        ? <div data-testid="right-rail-content">right rail</div>
+        : undefined}
+      mobileDefaultPane={opts.mobileDefaultPane}
+    />,
+  );
+}
+
+function paneVisibilityClasses() {
+  // The pane wrappers are siblings of the tab bar inside the workspace
+  // root. Reach through testid for the embedded children to land on the
+  // right wrapper element.
+  const left = screen.queryByTestId('left-rail-content')?.parentElement;
+  const middle = screen.getByTestId('embedded-chat-panel').parentElement!;
+  const right = screen.queryByTestId('right-rail-content')?.parentElement ?? null;
+  return { left, middle, right };
+}
+
+describe('ChatWorkspaceLayout — mobile tab navigation', () => {
+  it('renders a mobile tab bar with one entry per available pane', () => {
+    renderLayout({ withRightRail: true });
+
+    // Three tabs when a right rail is provided (Home + Chats + RentMate).
+    expect(screen.getByTestId('workspace-tab-right')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-tab-left')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-tab-middle')).toBeInTheDocument();
+  });
+
+  it('omits the right-rail tab when no right rail is supplied', () => {
+    renderLayout({ withRightRail: false });
+
+    expect(screen.queryByTestId('workspace-tab-right')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workspace-tab-left')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-tab-middle')).toBeInTheDocument();
+  });
+
+  it('marks the configured mobileDefaultPane tab as the active one on first paint', () => {
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    expect(screen.getByTestId('workspace-tab-right')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('workspace-tab-left')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('workspace-tab-middle')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('makes the active pane visible on mobile and hides the inactive ones', () => {
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    const { left, middle, right } = paneVisibilityClasses();
+
+    // Inactive mobile panes get the bare `hidden` utility so they
+    // collapse on small screens. The active pane uses `flex flex-1`
+    // (or `block flex-1` for the right rail).
+    // Match `hidden` only when it stands alone — `md:hidden` /
+    // `lg:hidden` are separate breakpoint-scoped utilities.
+    const bareHidden = /(?:^|\s)hidden(?:\s|$)/;
+    expect(bareHidden.test(left?.className ?? '')).toBe(true);
+    expect(bareHidden.test(middle.className)).toBe(true);
+    expect(bareHidden.test(right?.className ?? '')).toBe(false);
+    expect(right?.className).toMatch(/\bblock\b/);
+  });
+
+  it('switches the active pane when the user taps a tab', () => {
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    act(() => screen.getByTestId('workspace-tab-left').click());
+
+    expect(screen.getByTestId('workspace-tab-left')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('workspace-tab-right')).toHaveAttribute('aria-pressed', 'false');
+
+    const { left, middle, right } = paneVisibilityClasses();
+    expect(left?.className).toMatch(/\bflex flex-1\b/);
+    expect(middle.className).toContain('hidden');
+    expect(right?.className).toContain('hidden');
+  });
+
+  it('auto-switches to the middle (chat) pane when chatPanel.conversationId is set', () => {
+    chatPanelState = { ...chatPanelState, conversationId: 'conv-42' };
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    // The effect runs on mount because the dependency is non-null.
+    expect(screen.getByTestId('workspace-tab-middle')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('auto-switches to the middle pane when chatPanel.taskId is set', () => {
+    chatPanelState = { ...chatPanelState, taskId: 'task-7' };
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    expect(screen.getByTestId('workspace-tab-middle')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('auto-switches to the middle pane when chatPanel.suggestionId is set', () => {
+    chatPanelState = { ...chatPanelState, suggestionId: 's1' };
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    expect(screen.getByTestId('workspace-tab-middle')).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+describe('ChatWorkspaceLayout — desktop layout invariants', () => {
+  it('always tags every pane with the corresponding desktop visibility classes so md+ shows side-by-side regardless of mobile pane state', () => {
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    const { left, middle, right } = paneVisibilityClasses();
+
+    // Even though `left` is mobile-hidden, it carries the `md:flex`
+    // class so it appears at the md breakpoint.
+    expect(left?.className).toMatch(/\bmd:flex\b/);
+    // Middle is always shown at md+.
+    expect(middle.className).toMatch(/\bmd:flex\b/);
+    // The right rail uses lg:block — md width is too narrow for the
+    // dashboard's Action Desk so it stays hidden between md and lg.
+    expect(right?.className).toMatch(/\blg:block\b/);
+  });
+});

--- a/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.tsx
@@ -1,33 +1,129 @@
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
+import { Bot, LayoutDashboard, MessageCircle } from 'lucide-react';
 
 import { ChatPanel } from './ChatPanel';
+import { useApp } from '@/context/AppContext';
+import { cn } from '@/lib/utils';
+
+type Pane = 'left' | 'middle' | 'right';
+
+type PaneOption = {
+  key: Pane;
+  label: string;
+  icon: typeof Bot;
+};
+
+const PANE_OPTIONS: Record<Pane, PaneOption> = {
+  left: { key: 'left', label: 'Chats', icon: MessageCircle },
+  middle: { key: 'middle', label: 'RentMate', icon: Bot },
+  right: { key: 'right', label: 'Home', icon: LayoutDashboard },
+};
 
 /**
- * Shared 3-column "chat workspace" shell used by the dashboard and the
- * Chats page.
+ * Shared "chat workspace" shell used by the dashboard and the Chats page.
  *
- * - Left rail: caller-provided (typically a `ConversationListPane`).
- * - Middle: an embedded `ChatPanel` driven by the active chatPanel state.
- * - Right rail: optional. Omit for a 2-column layout where the chat fills
- *   the remaining width.
+ * **Desktop (≥md)**: a fixed three-column layout — left rail, embedded
+ * `ChatPanel`, optional right rail. The right rail only renders at lg+
+ * (the dashboard's Action Desk needs the width).
+ *
+ * **Mobile (<md)**: only one pane fits at a time, so the panes are
+ * stacked behind a top tab bar. The user lands on `mobileDefaultPane`
+ * (typically the most useful screen for that page — the dashboard's
+ * Home pane vs. the Chats page's conversation list) and can switch
+ * between the available panes. Selecting a conversation/task auto-
+ * switches to the chat pane so the tap-to-open flow doesn't dead-end.
  */
 export function ChatWorkspaceLayout({
   leftRail,
   rightRail,
+  mobileDefaultPane = 'left',
 }: {
   leftRail: ReactNode;
   rightRail?: ReactNode;
+  mobileDefaultPane?: Pane;
 }) {
+  const { chatPanel } = useApp();
+  const [pane, setPane] = useState<Pane>(mobileDefaultPane);
+
+  // Tap-through: when something opens a chat (conversation row, task
+  // card, suggestion link, etc.), bring the chat pane into view on
+  // mobile so the user actually sees the thread they just opened.
+  useEffect(() => {
+    if (chatPanel.conversationId || chatPanel.taskId || chatPanel.suggestionId) {
+      setPane('middle');
+    }
+  }, [chatPanel.conversationId, chatPanel.taskId, chatPanel.suggestionId]);
+
+  const tabs: PaneOption[] = rightRail
+    ? [PANE_OPTIONS.right, PANE_OPTIONS.left, PANE_OPTIONS.middle]
+    : [PANE_OPTIONS.left, PANE_OPTIONS.middle];
+
   return (
-    <div className="flex flex-col md:flex-row h-full">
-      <div className="w-72 min-w-[280px] shrink-0 border-r hidden md:flex flex-col h-full">
+    <div className="flex flex-col h-full md:flex-row">
+      {/* Mobile-only tab bar. Desktop hides it because all panes are
+          rendered side-by-side. */}
+      <div className="md:hidden flex shrink-0 border-b bg-card/40 backdrop-blur-sm">
+        {tabs.map((tab) => {
+          const Icon = tab.icon;
+          const active = pane === tab.key;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setPane(tab.key)}
+              aria-pressed={active}
+              data-testid={`workspace-tab-${tab.key}`}
+              className={cn(
+                'flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium transition-colors',
+                active
+                  ? 'border-b-2 border-primary text-foreground'
+                  : 'border-b-2 border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Left rail (conversation list).
+          Mobile: only when `pane === 'left'`. md+: always visible as a
+          fixed-width sidebar (md:flex-none cancels the mobile flex-1). */}
+      <div
+        className={cn(
+          'border-r min-h-0 flex-col',
+          pane === 'left' ? 'flex flex-1' : 'hidden',
+          'md:flex md:flex-none md:w-72 md:min-w-[280px] md:shrink-0 md:h-full',
+        )}
+      >
         {leftRail}
       </div>
-      <div className="flex-[2] min-w-0 flex flex-col h-full">
+
+      {/* Middle (embedded ChatPanel).
+          Mobile: only when `pane === 'middle'`. md+: grows to fill (flex-[2]). */}
+      <div
+        className={cn(
+          'min-w-0 min-h-0 flex-col',
+          pane === 'middle' ? 'flex flex-1' : 'hidden',
+          'md:flex md:flex-[2] md:h-full',
+        )}
+      >
         <ChatPanel embedded />
       </div>
+
+      {/* Right rail (Action Desk on the dashboard, omitted elsewhere).
+          Mobile: only when `pane === 'right'` (full-width).
+          md→<lg: hidden — md is too narrow for the dashboard widgets.
+          lg+: fixed-width sidebar. */}
       {rightRail && (
-        <div className="w-96 min-w-[360px] shrink-0 overflow-auto hidden lg:block border-l">
+        <div
+          className={cn(
+            'overflow-auto min-h-0',
+            pane === 'right' ? 'block flex-1' : 'hidden',
+            'md:hidden lg:block lg:w-96 lg:min-w-[360px] lg:shrink-0 lg:flex-none lg:border-l lg:h-full',
+          )}
+        >
           {rightRail}
         </div>
       )}

--- a/www/rentmate-ui/src/pages/Index.tsx
+++ b/www/rentmate-ui/src/pages/Index.tsx
@@ -282,7 +282,7 @@ const Index = () => {
     </div>
   );
 
-  return <ChatWorkspaceLayout leftRail={leftRail} rightRail={rightRail} />;
+  return <ChatWorkspaceLayout leftRail={leftRail} rightRail={rightRail} mobileDefaultPane="right" />;
 };
 
 export default Index;


### PR DESCRIPTION
## Summary

The dashboard and Chats pages were unusable on a phone — the 3-column workspace only ever showed the middle chat panel on `<md` widths. Both rails were `hidden md:flex` / `hidden lg:block` with no mobile fallback, so users couldn't reach the conversation list or the Action Desk.

`ChatWorkspaceLayout` now renders a top tab bar on mobile that swaps between the available panes. Desktop is unchanged.

### Mobile UX

- **Dashboard (`/`)**: tabs for *Home* (stats + Action Desk), *Chats* (conversation list), *RentMate* (embedded chat). Defaults to *Home* — the most useful landing screen on a phone.
- **Chats (`/chats`)**: tabs for *Chats* and *RentMate*. Defaults to *Chats*.
- **Tap-through**: selecting a conversation / task / suggestion (from any pane) auto-switches the active mobile tab to *RentMate* so the user lands on the thread they opened. A `useEffect` watching `chatPanel.{conversationId,taskId,suggestionId}` drives this, so every caller of `openChat` gets the behavior for free.

### Desktop

- `md+` keeps the side-by-side 3-column shell. Right rail still gates on `lg+`.
- The mobile-only tab bar hides at `md+` via `md:hidden`.
- Mobile pane state no longer leaks into the `md → <lg` gap because the right rail carries `md:hidden lg:block`.

## Tests

`ChatWorkspaceLayout.test.tsx` (new, 9 cases):
- Tab bar entries match the available panes (right + left + middle when right rail given; left + middle otherwise)
- `mobileDefaultPane` prop drives the active tab on first paint
- The bare `hidden` utility only lands on inactive panes
- Tab clicks switch the active pane
- Pre-set `chatPanel.{conversationId,taskId,suggestionId}` auto-activates the *RentMate* tab on mount
- Desktop invariant: every pane carries the appropriate `md:flex` / `lg:block` utility regardless of mobile pane state

UI suite: 107 passing.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 107 passing
- [ ] Manual on a real phone (or Chrome devtools mobile emulator):
  - [ ] Land on `/` → see Home pane (stats + Action Desk), tab bar at top
  - [ ] Tap *Chats* tab → conversation list
  - [ ] Tap a conversation → auto-switches to *RentMate* tab with that thread open
  - [ ] Tap a task card on *Home* → auto-switches to *RentMate* with the task chat open
  - [ ] Same flow on `/chats`
  - [ ] Resize across `md` breakpoint — desktop layout takes over with no flicker