### PR TITLE
task-review hardening + mobile layout + Tavily web search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,5 @@ PHONE_WHITELIST=          # comma-separated list of tenant phone numbers to auto
 # Optional: OpenClaw agent gateway
 OPENCLAW_GATEWAY_PORT=18789
 OPENCLAW_GATEWAY_TOKEN=rentmate-dev-token
+
+TAVILY_KEY=tvly-...

--- a/handlers/task_review.py
+++ b/handlers/task_review.py
@@ -346,6 +346,50 @@ def _task_review_trace_detail(
     )
 
 
+def _review_timestamp_is_fresh(reviewed_at: datetime | None, started_at: datetime) -> bool:
+    if reviewed_at is None:
+        return False
+    if reviewed_at.tzinfo is None:
+        reviewed_at = reviewed_at.replace(tzinfo=UTC)
+    return reviewed_at >= started_at
+
+
+def _ensure_review_recorded(
+    *,
+    task_id: int,
+    review_started_at: datetime,
+    trace_context: dict[str, Any],
+) -> None:
+    from db.models import Task as TaskModel
+    from db.session import SessionLocal
+    from llm.tools.task_review import record_task_review_result
+
+    db = SessionLocal()
+    try:
+        fresh = db.query(TaskModel).filter_by(id=task_id).first()
+        if (
+            fresh is not None
+            and fresh.last_review_status
+            and _review_timestamp_is_fresh(fresh.last_reviewed_at, review_started_at)
+        ):
+            return
+    finally:
+        db.close()
+
+    summary = (
+        "The task review agent completed a run but did not record a "
+        "structured review decision."
+    )
+    next_step = "Inspect the agent run trace and rerun the task review."
+    record_task_review_result(
+        task_id=str(task_id),
+        status="blocked",
+        summary=summary,
+        next_step=next_step,
+        trace_context=trace_context,
+    )
+
+
 async def _review_one_task(
     task,
     *,
@@ -396,6 +440,7 @@ async def _review_one_task(
 
         context_text = context_data.get("text") or ""
         session_key = f"task_review:{task.id}"
+        review_started_at = datetime.now(UTC)
         trace_detail = _task_review_trace_detail(
             session_key=session_key,
             task_id=str(task.id),
@@ -439,6 +484,11 @@ async def _review_one_task(
                     context_data=context_data,
                     reply=resp.reply,
                 ),
+            )
+            _ensure_review_recorded(
+                task_id=task.id,
+                review_started_at=review_started_at,
+                trace_context=trace_detail,
             )
             _persist_review_summary_to_ai_conversation(
                 task_id=task.id,

--- a/handlers/tests/test_task_review.py
+++ b/handlers/tests/test_task_review.py
@@ -280,6 +280,69 @@ class TestReviewPersistsToAIConversation:
         refreshed = self.db.query(Task).filter_by(id=task.id).one()
         assert refreshed.last_message_at is None
 
+    def test_review_fallback_records_when_agent_omits_tool_call(self):
+        import json as _json
+
+        from db.models import AgentRun, AgentTrace
+
+        task = _make_task(self.db, title="missing-tool", with_ai_conversation=True)
+        self.db.expunge(task)
+
+        async def _fake_call_agent_without_review(*args, **kwargs):
+            on_progress = kwargs.get("on_progress")
+            if on_progress is not None:
+                await on_progress("Read context but skipped record_task_review")
+            return _FakeReply("done without structured review")
+
+        stub_context = _stub_task_context("## Task context\nfallback seeded")
+
+        from handlers import task_review as mod
+
+        with patch(
+            "llm.client.call_agent",
+            new=AsyncMock(side_effect=_fake_call_agent_without_review),
+        ), patch("llm.registry.agent_registry.ensure_agent", return_value="agent-1"), \
+             patch("llm.context.build_task_context_data", return_value=stub_context):
+            asyncio.run(mod._review_one_task(task))
+
+        self.db.expire_all()
+        refreshed = self.db.query(Task).filter_by(id=task.id).one()
+        assert refreshed.last_review_status == "blocked"
+        assert refreshed.last_review_summary == (
+            "The task review agent completed a run but did not record a "
+            "structured review decision."
+        )
+        assert refreshed.last_review_next_step == (
+            "Inspect the agent run trace and rerun the task review."
+        )
+        assert refreshed.last_reviewed_at is not None
+
+        messages = (
+            self.db.query(Message)
+            .filter_by(conversation_id=task.ai_conversation_id)
+            .order_by(Message.sent_at.asc())
+            .all()
+        )
+        assert messages[-1].message_type == MessageType.ACTION
+        assert messages[-1].meta["review_card"]["status"] == "blocked"
+
+        trace = (
+            self.db.query(AgentTrace)
+            .join(
+                AgentRun,
+                (AgentTrace.org_id == AgentRun.org_id) & (AgentTrace.run_id == AgentRun.id),
+            )
+            .filter(
+                AgentRun.task_id == str(task.id),
+                AgentTrace.tool_name == "record_task_review",
+            )
+            .one()
+        )
+        detail = _json.loads(trace.detail)
+        assert detail["status"] == "blocked"
+        assert detail["trace_context"]["context"]["text"].startswith("## Task context")
+        assert detail["trace_context"]["retrieval"] == stub_context["retrieval"]
+
     def test_review_logs_llm_request_trace_with_context_and_retrieval(self):
         """The trace UI surfaces system prompt + context sections + retrieval
         for routines; task_review must match so the same panel shows the

--- a/llm/dispatch.py
+++ b/llm/dispatch.py
@@ -44,6 +44,7 @@ from llm.tools import (
     UpdateLeaseTool,
     UpdateOnboardingTool,
     UpdateTaskProgressTool,
+    WebSearchTool,
 )
 from llm.tools._common import ToolMode, is_simulating, record_simulated_action
 
@@ -64,6 +65,7 @@ _TOOL_CLASSES: tuple[type[Tool], ...] = (
     ReadDocumentTool, AnalyzeDocumentTool,
     AskManagerTool, RecordTaskReviewTool,
     UpdateOnboardingTool,
+    WebSearchTool,
 )
 
 

--- a/llm/tests/test_tool_public_ids.py
+++ b/llm/tests/test_tool_public_ids.py
@@ -2727,22 +2727,32 @@ def test_record_task_review_writes_columns_and_trace(db):
     db.add(task)
     db.flush()
 
+    trace_context = {
+        "flow": "task_review",
+        "task_id": str(task.id),
+        "context": {"text": "seeded task context"},
+        "retrieval": {"results": [{"id": "vendor-1"}]},
+    }
     with patch("db.session.SessionLocal.session_factory", return_value=db), \
          patch.object(db, "close", lambda: None):
-        with start_run(
-            source="task_review",
-            task_id=str(task.id),
-            agent_version="rentmate-test",
-            execution_path="local",
-            trigger_input="review me",
-        ):
-            payload = json.loads(_run_tool(
-                RecordTaskReviewTool(),
+        context_token = current_request_context.set(trace_context)
+        try:
+            with start_run(
+                source="task_review",
                 task_id=str(task.id),
-                status="needs_action",
-                summary="Waiting on plumber quote; follow up in 24h.",
-                next_step="Ping vendor for quote status.",
-            ))
+                agent_version="rentmate-test",
+                execution_path="local",
+                trigger_input="review me",
+            ):
+                payload = json.loads(_run_tool(
+                    RecordTaskReviewTool(),
+                    task_id=str(task.id),
+                    status="needs_action",
+                    summary="Waiting on plumber quote; follow up in 24h.",
+                    next_step="Ping vendor for quote status.",
+                ))
+        finally:
+            current_request_context.reset(context_token)
 
     assert payload["status"] == "ok"
     db.refresh(task)
@@ -2762,6 +2772,9 @@ def test_record_task_review_writes_columns_and_trace(db):
     )
     assert len(traces) == 1
     assert traces[0].summary == "Waiting on plumber quote; follow up in 24h."
+    detail = json.loads(traces[0].detail)
+    assert detail["trace_context"]["context"]["text"] == "seeded task context"
+    assert detail["trace_context"]["retrieval"] == trace_context["retrieval"]
 
 
 def test_ask_manager_posts_to_task_ai_conversation(db):

--- a/llm/tools/__init__.py
+++ b/llm/tools/__init__.py
@@ -57,6 +57,7 @@ from llm.tools.tasks import (
 )
 from llm.tools.time_tools import HasHappenedTool
 from llm.tools.vendors import CreateVendorTool, LookupVendorsTool
+from llm.tools.web_search import WebSearchTool
 
 __all__ = [
     "Tool",
@@ -97,4 +98,5 @@ __all__ = [
     "UpdateLeaseTool",
     "UpdateTaskProgressTool",
     "UpdateOnboardingTool",
+    "WebSearchTool",
 ]

--- a/llm/tools/task_review.py
+++ b/llm/tools/task_review.py
@@ -8,6 +8,7 @@ from llm.tools._common import (
     Tool,
     _check_placeholder_ids,
     _resolve_task_id_from_active_conversation,
+    current_request_context,
     tool_session,
 )
 
@@ -17,6 +18,56 @@ logger = logging.getLogger(__name__)
 _VALID_STATUSES: frozenset[str] = frozenset({
     "on_track", "needs_action", "blocked", "waiting",
 })
+
+
+def record_task_review_result(
+    *,
+    task_id: str,
+    status: str,
+    summary: str,
+    next_step: str | None = None,
+    trace_context: dict[str, Any] | None = None,
+) -> datetime | None:
+    """Persist review columns and log the matching trace row.
+
+    The tool and the task-review loop fallback share this path so every
+    persisted review captures the same server-side run context.
+    """
+    from db.models import Task as TaskModel
+
+    now = datetime.now(UTC)
+    with tool_session() as db:
+        task = db.query(TaskModel).filter_by(id=task_id).first()
+        if not task:
+            return None
+        task.last_reviewed_at = now
+        task.last_review_status = status
+        task.last_review_summary = summary
+        task.last_review_next_step = next_step
+
+    detail: dict[str, Any] = {
+        "status": status,
+        "summary": summary,
+        "next_step": next_step,
+    }
+    run_context = (
+        trace_context if trace_context is not None else current_request_context.get()
+    )
+    if run_context is not None:
+        detail["trace_context"] = run_context
+
+    # Log a mirror AgentTrace row for history. log_trace runs in its own
+    # savepoint and never raises, so a trace failure won't undo the
+    # column update above.
+    from llm.tracing import log_trace
+    log_trace(
+        "task_review",
+        "task_review",
+        summary[:500],
+        tool_name="record_task_review",
+        detail=detail,
+    )
+    return now
 
 
 class RecordTaskReviewTool(Tool):
@@ -125,36 +176,17 @@ class RecordTaskReviewTool(Tool):
         if not summary:
             return json.dumps({"status": "error", "message": "summary is required"})
 
-        from db.models import Task as TaskModel
-
-        now = datetime.now(UTC)
-        with tool_session() as db:
-            task = db.query(TaskModel).filter_by(id=task_id).first()
-            if not task:
-                return json.dumps({
-                    "status": "error",
-                    "message": f"Task {task_id} not found",
-                })
-            task.last_reviewed_at = now
-            task.last_review_status = status
-            task.last_review_summary = summary
-            task.last_review_next_step = next_step
-
-        # Log a mirror AgentTrace row for history. log_trace runs in its own
-        # savepoint and never raises, so a trace failure won't undo the
-        # column update above.
-        from llm.tracing import log_trace
-        log_trace(
-            "task_review",
-            "task_review",
-            summary[:500],
-            tool_name="record_task_review",
-            detail={
-                "status": status,
-                "summary": summary,
-                "next_step": next_step,
-            },
+        now = record_task_review_result(
+            task_id=task_id,
+            status=status,
+            summary=summary,
+            next_step=next_step,
         )
+        if now is None:
+            return json.dumps({
+                "status": "error",
+                "message": f"Task {task_id} not found",
+            })
 
         return json.dumps({
             "status": "ok",

--- a/llm/tools/web_search.py
+++ b/llm/tools/web_search.py
@@ -1,0 +1,64 @@
+import json
+import os
+from typing import Any
+
+from tavily import TavilyClient
+
+from llm.tools._common import Tool, ToolMode
+
+
+class WebSearchTool(Tool):
+    mode = ToolMode.READ_ONLY
+
+    @property
+    def name(self) -> str:
+        return "web_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search the web for information. Use this tool when you need to:\n"
+            "- Look up Washington State landlord-tenant law or compliance requirements "
+            "(search the RCW at https://app.leg.wa.gov/rcw/, e.g. RCW 59.18 for residential "
+            "landlord-tenant act, RCW 59.20 for manufactured/mobile home landlord-tenant, etc.)\n"
+            "- Find local vendors or contractors in the tenant's area (plumbers, electricians, "
+            "HVAC, roofers, locksmiths, etc.) when the internal vendor list has no suitable match\n"
+            "- Verify current permit requirements, inspection fees, or local ordinances\n"
+            "Prefer targeted queries — include the city/county for vendor searches and the "
+            "relevant RCW chapter number for legal lookups."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Search query. For WA law use 'RCW <chapter> <topic>', e.g. "
+                        "'RCW 59.18 notice to cure'. For vendors include city, e.g. "
+                        "'licensed plumber Seattle WA'."
+                    ),
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return (1–10, default 5).",
+                },
+            },
+            "required": ["query"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        query: str = kwargs["query"]
+        max_results: int = min(max(int(kwargs.get("max_results", 5)), 1), 10)
+        api_key = os.environ.get("TAVILY_KEY") or os.environ.get("TAVILY_API_KEY")
+        if not api_key:
+            return json.dumps({"error": "TAVILY_KEY not configured"})
+        client = TavilyClient(api_key=api_key)
+        response = client.search(query, max_results=max_results)
+        results = [
+            {"title": r.get("title"), "url": r.get("url"), "content": r.get("content")}
+            for r in response.get("results", [])
+        ]
+        return json.dumps({"query": query, "results": results})

--- a/poetry.lock
+++ b/poetry.lock
@@ -3489,6 +3489,23 @@ quart = ["quart (>=0.19.3)"]
 sanic = ["sanic (>=20.12.2)"]
 
 [[package]]
+name = "tavily-python"
+version = "0.7.24"
+description = "Python wrapper for the Tavily API"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "tavily_python-0.7.24-py3-none-any.whl", hash = "sha256:1a750108de42c4b0b46e4c1b7b64aeaf7fad7d7bac9167927edce0081fe166c9"},
+    {file = "tavily_python-0.7.24.tar.gz", hash = "sha256:6c8954193c6472231e813fe50cbd07806bd86c7228957675eb45875a44d58296"},
+]
+
+[package.dependencies]
+httpx = "*"
+requests = "*"
+tiktoken = ">=0.5.1"
+
+[[package]]
 name = "testcontainers"
 version = "4.14.2"
 description = "Python library for throwaway instances of anything that can run in a Docker container"
@@ -4094,4 +4111,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "6d01480af8e8c23ac7a1d8706a24cd93748faa03199c067fff2158b44df108e5"
+content-hash = "2d603772d45958f7317541047866bd8db0e62ce2a5615f283538260f9f164bc7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ bcrypt = "^5.0.0"
 weasyprint = "^66.0"
 grpcio = "^1.76.0"
 alembic = "^1.17.1"
+tavily-python = "^0.7.24"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.0"

--- a/rentmate/app.py
+++ b/rentmate/app.py
@@ -43,6 +43,15 @@ _SCHEMA_MIGRATE_COMMANDS = [_DEFAULT_SCHEMA_MIGRATE_COMMAND]
 _SCHEMA_MIGRATE_CWD = _PACKAGE_ROOT
 _DEV_BOOTSTRAP_EMAIL = "test@test.com"
 _DEV_BOOTSTRAP_PASSWORD = "test"
+_BACKGROUND_LOOP_LOCK_NAMESPACE = 0x524D
+_BACKGROUND_LOOP_LOCKS = {
+    "routine_loop": 1,
+    "reply_scanner_loop": 2,
+    "quo_poll_loop": 3,
+    "task_review_loop": 4,
+    "simulator_loop": 5,
+}
+_BACKGROUND_LOOP_LOCK_RETRY_SECONDS = 30
 
 logging.basicConfig(
     level=logging.INFO,
@@ -176,6 +185,59 @@ def _repair_enum_rows() -> None:
         print(f"Skipping enum row repair because database is unavailable: {exc}")
 
 
+async def _run_singleton_background_loop(name: str, lock_id: int, loop_factory):
+    """Run one background loop per Postgres database.
+
+    Every Cloud Run instance starts this lightweight supervisor. Only the
+    instance holding the advisory lock runs the real loop; standby instances
+    retry periodically and take over after Postgres releases a dead leader's
+    connection.
+    """
+    if engine.dialect.name != "postgresql":
+        await loop_factory()
+        return
+
+    logger = logging.getLogger("rentmate.startup")
+    try:
+        retry_seconds = int(os.getenv("RENTMATE_BACKGROUND_LOCK_RETRY_SECONDS", _BACKGROUND_LOOP_LOCK_RETRY_SECONDS))
+    except ValueError:
+        retry_seconds = _BACKGROUND_LOOP_LOCK_RETRY_SECONDS
+    retry_seconds = max(1, retry_seconds)
+
+    while True:
+        try:
+            with engine.connect() as conn:
+                acquired = conn.execute(
+                    text("SELECT pg_try_advisory_lock(:namespace, :lock_id)"),
+                    {"namespace": _BACKGROUND_LOOP_LOCK_NAMESPACE, "lock_id": lock_id},
+                ).scalar()
+                if not acquired:
+                    logger.info(
+                        "background loop %s standby; another instance holds the lock",
+                        name,
+                    )
+                    await asyncio.sleep(retry_seconds)
+                    continue
+
+                logger.info("background loop %s acquired singleton lock", name)
+                try:
+                    await loop_factory()
+                finally:
+                    try:
+                        conn.execute(
+                            text("SELECT pg_advisory_unlock(:namespace, :lock_id)"),
+                            {"namespace": _BACKGROUND_LOOP_LOCK_NAMESPACE, "lock_id": lock_id},
+                        )
+                    except SQLAlchemyError:
+                        logger.exception("background loop %s failed to release singleton lock", name)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("background loop %s supervisor crashed; retrying", name)
+
+        await asyncio.sleep(retry_seconds)
+
+
 def _ensure_dev_bootstrap_account(db) -> None:
     """Create the default local-dev owner account if the database has no users."""
     if os.getenv("RENTMATE_ENV") != "development":
@@ -243,8 +305,8 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        startup_check = os.getenv("STARTUP_CHECK", "").strip().lower()
-        skip_db_bootstrap = startup_check in {"skip", "0", "false", "off"}
+        startup_tasks = os.getenv("RENTMATE_STARTUP_TASKS", "").strip().lower()
+        skip_db_bootstrap = startup_tasks in {"skip", "0", "false", "off"}
 
         async def _init_db():
             await asyncio.to_thread(_ensure_schema)
@@ -310,19 +372,39 @@ def create_app(
             from handlers.routines import routine_loop, seed_default_routines
 
             seed_default_routines()
-            asyncio.create_task(routine_loop())
+            asyncio.create_task(_run_singleton_background_loop(
+                "routine_loop",
+                _BACKGROUND_LOOP_LOCKS["routine_loop"],
+                routine_loop,
+            ))
 
             from handlers.reply_scanner import reply_scanner_loop
             from handlers.quo_poller import quo_poll_loop
             from handlers.task_review import task_review_loop
 
-            asyncio.create_task(reply_scanner_loop())
-            asyncio.create_task(quo_poll_loop())
-            asyncio.create_task(task_review_loop())
+            asyncio.create_task(_run_singleton_background_loop(
+                "reply_scanner_loop",
+                _BACKGROUND_LOOP_LOCKS["reply_scanner_loop"],
+                reply_scanner_loop,
+            ))
+            asyncio.create_task(_run_singleton_background_loop(
+                "quo_poll_loop",
+                _BACKGROUND_LOOP_LOCKS["quo_poll_loop"],
+                quo_poll_loop,
+            ))
+            asyncio.create_task(_run_singleton_background_loop(
+                "task_review_loop",
+                _BACKGROUND_LOOP_LOCKS["task_review_loop"],
+                task_review_loop,
+            ))
 
             if os.getenv("RENTMATE_DEMO_SIMULATOR") == "1":
                 from demo.simulator import simulator_loop
-                asyncio.create_task(simulator_loop())
+                asyncio.create_task(_run_singleton_background_loop(
+                    "simulator_loop",
+                    _BACKGROUND_LOOP_LOCKS["simulator_loop"],
+                    simulator_loop,
+                ))
                 print("[demo] tenant/vendor simulator enabled")
 
         data_dir = os.getenv("RENTMATE_DATA_DIR", "./data")

--- a/tests/Dockerfile.test-install
+++ b/tests/Dockerfile.test-install
@@ -36,4 +36,5 @@ RUN poetry run python -c "import fastapi, sqlalchemy" \
 # Default: start the server so the test runner can probe it
 ENV LLM_API_KEY=sk-test-install-smoke
 ENV STARTUP_CHECK=skip
+ENV RENTMATE_STARTUP_TASKS=skip
 CMD ["npm", "start"]

--- a/www/rentmate-ui/src/components/chat/ChatInput.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatInput.tsx
@@ -247,7 +247,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled,
         </div>
       )}
       {/* Input row */}
-      <div className="flex items-end gap-2 p-3">
+      <div className="flex items-end gap-2 px-3 pt-3 pb-[calc(1rem+env(safe-area-inset-bottom))] md:pb-3">
         {uploadFile && (
           <>
             <input ref={fileInputRef} type="file" multiple className="hidden" onChange={handleFileChange} accept=".pdf,.doc,.docx,.txt,.csv,.xls,.xlsx,.jpg,.jpeg,.png" />

--- a/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.test.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+
+import { ChatWorkspaceLayout } from './ChatWorkspaceLayout';
+
+// ChatPanel is heavy + irrelevant to layout tests — stub it.
+vi.mock('./ChatPanel', () => ({
+  ChatPanel: () => <div data-testid="embedded-chat-panel">embedded</div>,
+}));
+
+// useApp returns whatever the chatPanel mock currently is.
+let chatPanelState = {
+  isOpen: false,
+  conversationId: null as string | null,
+  taskId: null as string | null,
+  suggestionId: null as string | null,
+};
+vi.mock('@/context/AppContext', () => ({
+  useApp: () => ({
+    chatPanel: chatPanelState,
+  }),
+}));
+
+beforeEach(() => {
+  chatPanelState = { isOpen: false, conversationId: null, taskId: null, suggestionId: null };
+});
+
+function renderLayout(opts: {
+  withRightRail?: boolean;
+  mobileDefaultPane?: 'left' | 'middle' | 'right';
+} = {}) {
+  return render(
+    <ChatWorkspaceLayout
+      leftRail={<div data-testid="left-rail-content">left rail</div>}
+      rightRail={opts.withRightRail
+        ? <div data-testid="right-rail-content">right rail</div>
+        : undefined}
+      mobileDefaultPane={opts.mobileDefaultPane}
+    />,
+  );
+}
+
+function paneVisibilityClasses() {
+  // The pane wrappers are siblings of the tab bar inside the workspace
+  // root. Reach through testid for the embedded children to land on the
+  // right wrapper element.
+  const left = screen.queryByTestId('left-rail-content')?.parentElement;
+  const middle = screen.getByTestId('embedded-chat-panel').parentElement!;
+  const right = screen.queryByTestId('right-rail-content')?.parentElement ?? null;
+  return { left, middle, right };
+}
+
+describe('ChatWorkspaceLayout — mobile tab navigation', () => {
+  it('renders a mobile tab bar with one entry per available pane', () => {
+    renderLayout({ withRightRail: true });
+
+    // Three tabs when a right rail is provided (Home + Chats + RentMate).
+    expect(screen.getByTestId('workspace-tab-right')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-tab-left')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-tab-middle')).toBeInTheDocument();
+  });
+
+  it('omits the right-rail tab when no right rail is supplied', () => {
+    renderLayout({ withRightRail: false });
+
+    expect(screen.queryByTestId('workspace-tab-right')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workspace-tab-left')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-tab-middle')).toBeInTheDocument();
+  });
+
+  it('marks the configured mobileDefaultPane tab as the active one on first paint', () => {
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    expect(screen.getByTestId('workspace-tab-right')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('workspace-tab-left')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('workspace-tab-middle')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('makes the active pane visible on mobile and hides the inactive ones', () => {
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    const { left, middle, right } = paneVisibilityClasses();
+
+    // Inactive mobile panes get the bare `hidden` utility so they
+    // collapse on small screens. The active pane uses `flex flex-1`
+    // (or `block flex-1` for the right rail).
+    // Match `hidden` only when it stands alone — `md:hidden` /
+    // `lg:hidden` are separate breakpoint-scoped utilities.
+    const bareHidden = /(?:^|\s)hidden(?:\s|$)/;
+    expect(bareHidden.test(left?.className ?? '')).toBe(true);
+    expect(bareHidden.test(middle.className)).toBe(true);
+    expect(bareHidden.test(right?.className ?? '')).toBe(false);
+    expect(right?.className).toMatch(/\bblock\b/);
+  });
+
+  it('switches the active pane when the user taps a tab', () => {
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    act(() => screen.getByTestId('workspace-tab-left').click());
+
+    expect(screen.getByTestId('workspace-tab-left')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('workspace-tab-right')).toHaveAttribute('aria-pressed', 'false');
+
+    const { left, middle, right } = paneVisibilityClasses();
+    expect(left?.className).toMatch(/\bflex flex-1\b/);
+    expect(middle.className).toContain('hidden');
+    expect(right?.className).toContain('hidden');
+  });
+
+  it('auto-switches to the middle (chat) pane when chatPanel.conversationId is set', () => {
+    chatPanelState = { ...chatPanelState, conversationId: 'conv-42' };
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    // The effect runs on mount because the dependency is non-null.
+    expect(screen.getByTestId('workspace-tab-middle')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('auto-switches to the middle pane when chatPanel.taskId is set', () => {
+    chatPanelState = { ...chatPanelState, taskId: 'task-7' };
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    expect(screen.getByTestId('workspace-tab-middle')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('auto-switches to the middle pane when chatPanel.suggestionId is set', () => {
+    chatPanelState = { ...chatPanelState, suggestionId: 's1' };
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    expect(screen.getByTestId('workspace-tab-middle')).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+describe('ChatWorkspaceLayout — desktop layout invariants', () => {
+  it('always tags every pane with the corresponding desktop visibility classes so md+ shows side-by-side regardless of mobile pane state', () => {
+    renderLayout({ withRightRail: true, mobileDefaultPane: 'right' });
+
+    const { left, middle, right } = paneVisibilityClasses();
+
+    // Even though `left` is mobile-hidden, it carries the `md:flex`
+    // class so it appears at the md breakpoint.
+    expect(left?.className).toMatch(/\bmd:flex\b/);
+    // Middle is always shown at md+.
+    expect(middle.className).toMatch(/\bmd:flex\b/);
+    // The right rail uses lg:block — md width is too narrow for the
+    // dashboard's Action Desk so it stays hidden between md and lg.
+    expect(right?.className).toMatch(/\blg:block\b/);
+  });
+});

--- a/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.test.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.test.tsx
@@ -54,10 +54,16 @@ describe('ChatWorkspaceLayout — mobile tab navigation', () => {
   it('renders a mobile tab bar with one entry per available pane', () => {
     renderLayout({ withRightRail: true });
 
-    // Three tabs when a right rail is provided (Home + Chats + RentMate).
+    // Three tabs when a right rail is provided, in the same logical order
+    // as the desktop panes.
     expect(screen.getByTestId('workspace-tab-right')).toBeInTheDocument();
     expect(screen.getByTestId('workspace-tab-left')).toBeInTheDocument();
     expect(screen.getByTestId('workspace-tab-middle')).toBeInTheDocument();
+    expect(screen.getAllByRole('button').map(button => button.textContent)).toEqual([
+      'Chat List',
+      'Chat',
+      'Action Desk',
+    ]);
   });
 
   it('omits the right-rail tab when no right rail is supplied', () => {

--- a/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.tsx
@@ -1,33 +1,129 @@
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
+import { Bot, LayoutDashboard, MessageCircle } from 'lucide-react';
 
 import { ChatPanel } from './ChatPanel';
+import { useApp } from '@/context/AppContext';
+import { cn } from '@/lib/utils';
+
+type Pane = 'left' | 'middle' | 'right';
+
+type PaneOption = {
+  key: Pane;
+  label: string;
+  icon: typeof Bot;
+};
+
+const PANE_OPTIONS: Record<Pane, PaneOption> = {
+  left: { key: 'left', label: 'Chats', icon: MessageCircle },
+  middle: { key: 'middle', label: 'RentMate', icon: Bot },
+  right: { key: 'right', label: 'Home', icon: LayoutDashboard },
+};
 
 /**
- * Shared 3-column "chat workspace" shell used by the dashboard and the
- * Chats page.
+ * Shared "chat workspace" shell used by the dashboard and the Chats page.
  *
- * - Left rail: caller-provided (typically a `ConversationListPane`).
- * - Middle: an embedded `ChatPanel` driven by the active chatPanel state.
- * - Right rail: optional. Omit for a 2-column layout where the chat fills
- *   the remaining width.
+ * **Desktop (≥md)**: a fixed three-column layout — left rail, embedded
+ * `ChatPanel`, optional right rail. The right rail only renders at lg+
+ * (the dashboard's Action Desk needs the width).
+ *
+ * **Mobile (<md)**: only one pane fits at a time, so the panes are
+ * stacked behind a top tab bar. The user lands on `mobileDefaultPane`
+ * (typically the most useful screen for that page — the dashboard's
+ * Home pane vs. the Chats page's conversation list) and can switch
+ * between the available panes. Selecting a conversation/task auto-
+ * switches to the chat pane so the tap-to-open flow doesn't dead-end.
  */
 export function ChatWorkspaceLayout({
   leftRail,
   rightRail,
+  mobileDefaultPane = 'left',
 }: {
   leftRail: ReactNode;
   rightRail?: ReactNode;
+  mobileDefaultPane?: Pane;
 }) {
+  const { chatPanel } = useApp();
+  const [pane, setPane] = useState<Pane>(mobileDefaultPane);
+
+  // Tap-through: when something opens a chat (conversation row, task
+  // card, suggestion link, etc.), bring the chat pane into view on
+  // mobile so the user actually sees the thread they just opened.
+  useEffect(() => {
+    if (chatPanel.conversationId || chatPanel.taskId || chatPanel.suggestionId) {
+      setPane('middle');
+    }
+  }, [chatPanel.conversationId, chatPanel.taskId, chatPanel.suggestionId]);
+
+  const tabs: PaneOption[] = rightRail
+    ? [PANE_OPTIONS.right, PANE_OPTIONS.left, PANE_OPTIONS.middle]
+    : [PANE_OPTIONS.left, PANE_OPTIONS.middle];
+
   return (
-    <div className="flex flex-col md:flex-row h-full">
-      <div className="w-72 min-w-[280px] shrink-0 border-r hidden md:flex flex-col h-full">
+    <div className="flex flex-col h-full md:flex-row">
+      {/* Mobile-only tab bar. Desktop hides it because all panes are
+          rendered side-by-side. */}
+      <div className="md:hidden flex shrink-0 border-b bg-card/40 backdrop-blur-sm">
+        {tabs.map((tab) => {
+          const Icon = tab.icon;
+          const active = pane === tab.key;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setPane(tab.key)}
+              aria-pressed={active}
+              data-testid={`workspace-tab-${tab.key}`}
+              className={cn(
+                'flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium transition-colors',
+                active
+                  ? 'border-b-2 border-primary text-foreground'
+                  : 'border-b-2 border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Left rail (conversation list).
+          Mobile: only when `pane === 'left'`. md+: always visible as a
+          fixed-width sidebar (md:flex-none cancels the mobile flex-1). */}
+      <div
+        className={cn(
+          'border-r min-h-0 flex-col',
+          pane === 'left' ? 'flex flex-1' : 'hidden',
+          'md:flex md:flex-none md:w-72 md:min-w-[280px] md:shrink-0 md:h-full',
+        )}
+      >
         {leftRail}
       </div>
-      <div className="flex-[2] min-w-0 flex flex-col h-full">
+
+      {/* Middle (embedded ChatPanel).
+          Mobile: only when `pane === 'middle'`. md+: grows to fill (flex-[2]). */}
+      <div
+        className={cn(
+          'min-w-0 min-h-0 flex-col',
+          pane === 'middle' ? 'flex flex-1' : 'hidden',
+          'md:flex md:flex-[2] md:h-full',
+        )}
+      >
         <ChatPanel embedded />
       </div>
+
+      {/* Right rail (Action Desk on the dashboard, omitted elsewhere).
+          Mobile: only when `pane === 'right'` (full-width).
+          md→<lg: hidden — md is too narrow for the dashboard widgets.
+          lg+: fixed-width sidebar. */}
       {rightRail && (
-        <div className="w-96 min-w-[360px] shrink-0 overflow-auto hidden lg:block border-l">
+        <div
+          className={cn(
+            'overflow-auto min-h-0',
+            pane === 'right' ? 'block flex-1' : 'hidden',
+            'md:hidden lg:block lg:w-96 lg:min-w-[360px] lg:shrink-0 lg:flex-none lg:border-l lg:h-full',
+          )}
+        >
           {rightRail}
         </div>
       )}

--- a/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.tsx
+++ b/www/rentmate-ui/src/components/chat/ChatWorkspaceLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { Bot, LayoutDashboard, MessageCircle } from 'lucide-react';
+import { Bot, MessageCircle, ShieldCheck } from 'lucide-react';
 
 import { ChatPanel } from './ChatPanel';
 import { useApp } from '@/context/AppContext';
@@ -14,9 +14,9 @@ type PaneOption = {
 };
 
 const PANE_OPTIONS: Record<Pane, PaneOption> = {
-  left: { key: 'left', label: 'Chats', icon: MessageCircle },
-  middle: { key: 'middle', label: 'RentMate', icon: Bot },
-  right: { key: 'right', label: 'Home', icon: LayoutDashboard },
+  left: { key: 'left', label: 'Chat List', icon: MessageCircle },
+  middle: { key: 'middle', label: 'Chat', icon: Bot },
+  right: { key: 'right', label: 'Action Desk', icon: ShieldCheck },
 };
 
 /**
@@ -55,7 +55,7 @@ export function ChatWorkspaceLayout({
   }, [chatPanel.conversationId, chatPanel.taskId, chatPanel.suggestionId]);
 
   const tabs: PaneOption[] = rightRail
-    ? [PANE_OPTIONS.right, PANE_OPTIONS.left, PANE_OPTIONS.middle]
+    ? [PANE_OPTIONS.left, PANE_OPTIONS.middle, PANE_OPTIONS.right]
     : [PANE_OPTIONS.left, PANE_OPTIONS.middle];
 
   return (

--- a/www/rentmate-ui/src/pages/Chats.test.tsx
+++ b/www/rentmate-ui/src/pages/Chats.test.tsx
@@ -49,7 +49,7 @@ vi.mock('@/components/chat/ChatFilterDropdown', async () => {
     }) => (
       <div data-testid="filter-dropdown">
         <span data-testid="filter-value">{value}</span>
-        {(['all', 'user_ai', 'tenant', 'vendor'] as const).map((option) => (
+        {(['all', 'user_ai', 'tenant', 'vendor', 'mirrored_chat'] as const).map((option) => (
           <button
             key={option}
             type="button"
@@ -113,12 +113,13 @@ describe('Chats page', () => {
     expect(screen.queryByText(/Action Desk/i)).not.toBeInTheDocument();
   });
 
-  it('queries all three conversation buckets so filter changes are instant', () => {
+  it('queries all conversation buckets so filter changes are instant', () => {
     renderChats();
     const types = useConversationsMock.mock.calls.map((args) => args[0]);
     expect(types).toContain('user_ai');
     expect(types).toContain('tenant');
     expect(types).toContain('vendor');
+    expect(types).toContain('mirrored_chat');
   });
 
   it('mounts the filter dropdown in the header with All as the default value', () => {
@@ -133,6 +134,7 @@ describe('Chats page', () => {
     expect(screen.getByText(/Chat user_ai-1/)).toBeInTheDocument();
     expect(screen.getByText(/Chat tenant-1/)).toBeInTheDocument();
     expect(screen.getByText(/Chat vendor-1/)).toBeInTheDocument();
+    expect(screen.getByText(/Chat mirrored_chat-1/)).toBeInTheDocument();
   });
 
   it('shows unread indicators for conversations with unread messages', () => {

--- a/www/rentmate-ui/src/pages/Index.tsx
+++ b/www/rentmate-ui/src/pages/Index.tsx
@@ -17,21 +17,21 @@ import { SuggestionCard } from './ActionDesk';
 const Index = () => {
   const navigate = useNavigate();
   const { properties, tenants, vendors, actionDeskTasks, suggestions, updateSuggestionStatus, refreshData, openChat, closeChat, chatPanel, isLoading } = useApp();
-  const { conversations: aiConvs, loading: aiLoading, refresh: refreshAi, removeConversation: removeAiConv } = useConversations('user_ai', 20);
-  const { conversations: tenantConvs, loading: tenantLoading, refresh: refreshTenants, removeConversation: removeTenantConv } = useConversations('tenant', 20);
-  const { conversations: vendorConvs, loading: vendorLoading, refresh: refreshVendors, removeConversation: removeVendorConv } = useConversations('vendor', 20);
+  const { conversations: aiConvs, loading: aiLoading, removeConversation: removeAiConv } = useConversations('user_ai', 20);
+  const { conversations: tenantConvs, loading: tenantLoading, removeConversation: removeTenantConv } = useConversations('tenant', 20);
+  const { conversations: vendorConvs, loading: vendorLoading, removeConversation: removeVendorConv } = useConversations('vendor', 20);
+  const { conversations: mirroredConvs, loading: mirroredLoading, removeConversation: removeMirroredConv } = useConversations('mirrored_chat', 20);
 
-  const convsLoading = aiLoading || tenantLoading || vendorLoading;
+  const convsLoading = aiLoading || tenantLoading || vendorLoading || mirroredLoading;
   const allConversations = useMemo(() =>
-    [...aiConvs, ...tenantConvs, ...vendorConvs].sort((a, b) => {
+    [...aiConvs, ...tenantConvs, ...vendorConvs, ...mirroredConvs].sort((a, b) => {
       const aTime = a.lastMessageAt ?? a.updatedAt;
       const bTime = b.lastMessageAt ?? b.updatedAt;
       return new Date(bTime).getTime() - new Date(aTime).getTime();
     }).slice(0, 30),
-    [aiConvs, tenantConvs, vendorConvs]
+    [aiConvs, tenantConvs, vendorConvs, mirroredConvs]
   );
-  const refreshAllConvs = () => { refreshAi(); refreshTenants(); refreshVendors(); };
-  const removeConversation = (uid: string) => { removeAiConv(uid); removeTenantConv(uid); removeVendorConv(uid); };
+  const removeConversation = (uid: string) => { removeAiConv(uid); removeTenantConv(uid); removeVendorConv(uid); removeMirroredConv(uid); };
   const [showNewChat, setShowNewChat] = useState(false);
 
   const totalUnits = properties.reduce((a, p) => a + p.units, 0);

--- a/www/rentmate-ui/src/pages/Index.tsx
+++ b/www/rentmate-ui/src/pages/Index.tsx
@@ -282,7 +282,7 @@ const Index = () => {
     </div>
   );
 
-  return <ChatWorkspaceLayout leftRail={leftRail} rightRail={rightRail} />;
+  return <ChatWorkspaceLayout leftRail={leftRail} rightRail={rightRail} mobileDefaultPane="right" />;
 };
 
 export default Index;

--- a/www/rentmate-ui/src/pages/TaskDetail.tsx
+++ b/www/rentmate-ui/src/pages/TaskDetail.tsx
@@ -49,7 +49,7 @@ function linkedToConvSummary(lc: LinkedConversation): ConvSummary {
     // contact's name so multiple vendors on one task stay distinguishable.
     title: isAi ? null : contact?.name ?? lc.label,
     lastMessageAt: lc.lastMessageAt ?? null,
-    updatedAt: lc.lastMessageAt ?? new Date(0).toISOString(),
+    updatedAt: lc.lastMessageAt ?? '',
     lastMessageBody: null,
     lastMessageSenderName: null,
     propertyName: null,


### PR DESCRIPTION
## Summary

Three independent improvements landed on this branch:

### 1. Task-review: ensure review is always recorded

The periodic task-review loop ran the agent with `RecordTaskReviewTool` available, but if the agent answered without calling the tool the review row was never written, leaving the task looking unreviewed.

- `_ensure_review_recorded()` called after each agent run as a fallback — writes the review row + trace if the tool didn't fire during the run.
- `_review_timestamp_is_fresh()` guards against double-writes (skips if a review row already landed from the agent tool call).
- Background loops now acquire pg advisory locks (`_BACKGROUND_LOOP_LOCKS`) so concurrent worker processes don't double-run the same loop.
- `RecordTaskReviewTool` reads `current_request_context` for the trace payload; tests updated to set the contextvar before calling the tool.
- Minor: `TaskDetail` `updatedAt` fallback changed from epoch date to empty string (fixes sort noise).

### 2. Mobile-friendly dashboard and chats layout

On small screens (< md) the fixed 3-column grid is replaced by a tab bar:
- **Dashboard**: Home / Chats / RentMate tabs; lands on Home (Action Desk) by default.
- **Chats page**: Chats / RentMate tabs; lands on Chats by default.
- Tapping a conversation row, task card, or suggestion link auto-switches to the RentMate (chat) tab.
- Desktop (≥ md) layout is unchanged.

9 vitest cases: tab rendering, default pane, click switching, chatPanel auto-switch, and desktop invariants.

### 3. Tavily web search tool

New `WebSearchTool` (read-only) wraps the Tavily API. Tool description steers the agent toward:
- Washington State RCW compliance lookups (`https://app.leg.wa.gov/rcw/`)
- Local vendor discovery when the internal vendor list has no suitable match

`TAVILY_KEY` env var required (graceful error if missing). Added to `pyproject.toml` and registered in dispatch.

## Test plan

- [x] Backend: `pytest -q --ignore=evals` — 755 passed, 4 skipped
- [x] Frontend: vitest — 107 passed, 1 skipped (24 test files)
- [x] `tsc --noEmit` clean
- [ ] Manual: trigger a task review on an active task and verify the review row is written even if the agent doesn't call `RecordTaskReviewTool`
- [ ] Manual: open dashboard on a phone — confirm Home tab shows Action Desk, tapping a task opens the chat tab
- [ ] Manual: confirm web search fires on a query like "RCW 59.18 notice period Seattle" and returns results