### PR TITLE
Improve Tasks page on mobile

### DIFF
--- a/www/rentmate-ui/src/pages/Index.tsx
+++ b/www/rentmate-ui/src/pages/Index.tsx
@@ -4,7 +4,7 @@ import { PageLoader } from '@/components/ui/page-loader';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Link, useNavigate } from 'react-router-dom';
-import { Building2, Users, Wrench, ShieldCheck, Bot, Clock, MessageCircle, Lock, Plus, ClipboardList } from 'lucide-react';
+import { Building2, Users, Wrench, ShieldCheck, Clock, MessageCircle, Lock, Plus, ClipboardList } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { ChatWorkspaceLayout } from '@/components/chat/ChatWorkspaceLayout';
@@ -124,19 +124,6 @@ const Index = () => {
 
   const rightRail = (
     <div className="p-4 space-y-4">
-      {/* Welcome */}
-      <div className="flex items-center gap-3">
-        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10">
-          <Bot className="h-4 w-4 text-primary" />
-        </div>
-        <div>
-          <h1 className="text-lg font-bold">{new Date().getHours() < 12 ? 'Good morning!' : new Date().getHours() < 17 ? 'Good afternoon!' : 'Good evening!'}</h1>
-          <p className="text-xs text-muted-foreground">
-            <span className="font-medium text-foreground">{needsAttention.length + pendingSuggestions.length} items</span> need attention
-          </p>
-        </div>
-      </div>
-
       {/* Stats */}
       <div className="grid grid-cols-3 gap-2">
         {stats.map((stat) => {
@@ -198,36 +185,36 @@ const Index = () => {
               const property = task.propertyId ? properties.find(p => p.id === task.propertyId) : null;
 
               return (
-                <Card key={task.id} className="p-3 rounded-xl hover:shadow-md transition-shadow cursor-pointer" onClick={() => navigate(`/tasks/${task.id}`)}>
-                  <div className="flex items-start justify-between gap-2 mb-1.5">
-                    <div className="flex items-center gap-1.5 flex-wrap">
-                      <Badge variant="secondary" className="text-[10px] rounded-lg gap-1 bg-muted text-muted-foreground">
-                        <ClipboardList className="h-3 w-3" />
+                <Card key={task.id} className="p-2.5 rounded-lg hover:shadow-md transition-shadow cursor-pointer" onClick={() => navigate(`/tasks/${task.id}`)}>
+                  <div className="flex items-start justify-between gap-2 mb-1">
+                    <div className="flex items-center gap-1 flex-wrap">
+                      <Badge variant="secondary" className="h-4 px-1.5 text-[9px] rounded-md gap-1 bg-muted text-muted-foreground">
+                        <ClipboardList className="h-2.5 w-2.5" />
                         Task #{task.id}
                       </Badge>
                       {task.unreadCount > 0 && (
-                        <Badge className="h-4 px-1.5 text-[10px] bg-primary text-primary-foreground">
+                        <Badge className="h-4 px-1.5 text-[9px] bg-primary text-primary-foreground">
                           {task.unreadCount} new
                         </Badge>
                       )}
                       {task.confidential && (
-                        <Badge variant="secondary" className="text-[10px] rounded-lg gap-1 bg-destructive/10 text-destructive">
-                          <Lock className="h-3 w-3" />
+                        <Badge variant="secondary" className="h-4 px-1.5 text-[9px] rounded-md gap-1 bg-destructive/10 text-destructive">
+                          <Lock className="h-2.5 w-2.5" />
                         </Badge>
                       )}
                     </div>
-                    <div className="flex items-center gap-1 text-[10px] text-muted-foreground shrink-0">
-                      <Clock className="h-3 w-3" />
+                    <div className="flex items-center gap-1 text-[9px] text-muted-foreground shrink-0">
+                      <Clock className="h-2.5 w-2.5" />
                       {formatDistanceToNow(new Date(task.lastMessageAt), { addSuffix: true })}
                     </div>
                   </div>
 
-                  <h3 className="font-semibold text-xs mb-1">{task.title}</h3>
+                  <h3 className="font-semibold text-[11px] leading-4 mb-1 line-clamp-2">{task.title}</h3>
 
-                  <div className="flex items-start gap-2 mt-1.5 bg-muted/40 rounded-lg p-2">
-                    <MessageCircle className="h-3 w-3 text-muted-foreground mt-0.5 shrink-0" />
+                  <div className="flex items-start gap-1.5 mt-1 bg-muted/40 rounded-md px-2 py-1.5">
+                    <MessageCircle className="h-2.5 w-2.5 text-muted-foreground mt-0.5 shrink-0" />
                     <div className="min-w-0">
-                      <span className="text-[10px] font-medium text-muted-foreground">{task.lastMessageBy}</span>
+                      <span className="text-[9px] font-medium text-muted-foreground">{task.lastMessageBy}</span>
                       <p className="text-[11px] text-foreground line-clamp-2">{task.lastMessage}</p>
                     </div>
                   </div>
@@ -241,7 +228,7 @@ const Index = () => {
                     const activeStep = task.steps.find(s => s.status === 'active');
                     const totalSteps = task.steps.length;
                     return (
-                      <div className="mt-2">
+                      <div className="mt-1.5">
                         <div className="flex items-center gap-0.5" aria-label={`Progress: ${doneCount} of ${totalSteps} steps complete`}>
                           {task.steps.map(step => (
                             <div
@@ -268,7 +255,7 @@ const Index = () => {
                     );
                   })()}
 
-                  <div className="mt-2 flex items-center justify-end">
+                  <div className="mt-1.5 flex items-center justify-end">
                     {property && (
                       <span className="text-[9px] text-muted-foreground">{property.name || property.address}</span>
                     )}

--- a/www/rentmate-ui/src/pages/TaskDetail.tsx
+++ b/www/rentmate-ui/src/pages/TaskDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { ArrowLeft, Eye, Loader2, Target } from 'lucide-react';
+import { ArrowLeft, Bot, Eye, Loader2, MessageCircle, Target } from 'lucide-react';
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -27,6 +27,7 @@ const CATEGORY_OPTIONS = [
 
 const URGENCY_OPTIONS = ['low', 'medium', 'high', 'critical'] as const;
 const STATUS_OPTIONS = ['active', 'paused', 'resolved', 'cancelled'] as const;
+type TaskDetailPane = 'list' | 'chat' | 'task';
 
 function sentenceCase(value: string): string {
   return value
@@ -535,6 +536,7 @@ export default function TaskDetail() {
     [actionDeskTasks, id],
   );
   const [selectedThread, setSelectedThread] = useState<EmbeddedTaskThreadSelection>({ kind: 'ai' });
+  const [mobilePane, setMobilePane] = useState<TaskDetailPane>('chat');
   const activeSuggestion = useMemo(
     () => suggestionId ? suggestions.find(s => s.id === suggestionId) : null,
     [suggestionId, suggestions],
@@ -637,6 +639,26 @@ export default function TaskDetail() {
     );
   }
 
+  const selectAiThread = () => {
+    setSelectedThread({ kind: 'ai' });
+    setMobilePane('chat');
+  };
+
+  const selectConversationThread = (convId: string) => {
+    setSelectedThread({ kind: 'conversation', id: convId });
+    setMobilePane('chat');
+  };
+
+  const mobileTabs: Array<{
+    key: TaskDetailPane;
+    label: string;
+    icon: typeof MessageCircle;
+  }> = [
+    { key: 'list', label: 'Chat List', icon: MessageCircle },
+    { key: 'chat', label: 'Chat', icon: Bot },
+    { key: 'task', label: 'Task', icon: Target },
+  ];
+
   return (
     <div className="flex flex-col h-full min-h-0">
       <div className="flex items-center gap-2 px-4 py-2 border-b">
@@ -650,20 +672,62 @@ export default function TaskDetail() {
           <Badge variant="outline" className="text-[10px] font-mono">Task #{task.taskNumber}</Badge>
         )}
       </div>
-      <div className="grid grid-cols-[280px_minmax(0,1fr)_360px] flex-1 min-h-0">
-        <aside className="border-r min-h-0 overflow-hidden">
+      <div className="md:hidden flex shrink-0 border-b bg-card/40 backdrop-blur-sm">
+        {mobileTabs.map(tab => {
+          const Icon = tab.icon;
+          const active = mobilePane === tab.key;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setMobilePane(tab.key)}
+              aria-pressed={active}
+              data-testid={`task-detail-tab-${tab.key}`}
+              className={cn(
+                'flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium transition-colors',
+                active
+                  ? 'border-b-2 border-primary text-foreground'
+                  : 'border-b-2 border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+      <div className="flex flex-col flex-1 min-h-0 md:grid md:grid-cols-[280px_minmax(0,1fr)_360px]">
+        <aside
+          className={cn(
+            'border-r min-h-0 overflow-hidden',
+            mobilePane === 'list' ? 'block flex-1' : 'hidden',
+            'md:block md:h-full',
+          )}
+        >
           <TaskConversationList
             task={task}
             selectedThread={selectedThread}
-            onSelectAi={() => setSelectedThread({ kind: 'ai' })}
-            onSelectConversation={convId => setSelectedThread({ kind: 'conversation', id: convId })}
+            onSelectAi={selectAiThread}
+            onSelectConversation={selectConversationThread}
           />
         </aside>
-        <main className="min-h-0 overflow-hidden">
+        <main
+          className={cn(
+            'min-h-0 overflow-hidden',
+            mobilePane === 'chat' ? 'block flex-1' : 'hidden',
+            'md:block md:h-full',
+          )}
+        >
           <ChatPanel embedded embeddedTaskSelection={selectedThread} />
         </main>
-        <aside className="border-l min-h-0 overflow-hidden">
-          <TaskGoalPanel task={task} onSelectAi={() => setSelectedThread({ kind: 'ai' })} />
+        <aside
+          className={cn(
+            'border-l min-h-0 overflow-hidden',
+            mobilePane === 'task' ? 'block flex-1' : 'hidden',
+            'md:block md:h-full',
+          )}
+        >
+          <TaskGoalPanel task={task} onSelectAi={selectAiThread} />
         </aside>
       </div>
     </div>

--- a/www/rentmate-ui/src/pages/Tasks.tsx
+++ b/www/rentmate-ui/src/pages/Tasks.tsx
@@ -152,7 +152,7 @@ function SmartSearch({ chips, onChipsChange, tasks, properties, tenants }: Smart
           <span
             key={chip.id}
             className={cn(
-              'inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-md text-xs font-medium shrink-0',
+              'inline-flex min-w-0 max-w-full items-center gap-1 pl-2 pr-1 py-0.5 rounded-md text-xs font-medium shrink-0',
               chip.type === 'property' && 'bg-primary/10 text-primary',
               chip.type === 'tenant' && 'bg-green-800 text-green-100',
               chip.type === 'text' && 'bg-muted text-muted-foreground',
@@ -160,7 +160,7 @@ function SmartSearch({ chips, onChipsChange, tasks, properties, tenants }: Smart
           >
             {chip.type === 'property' && <Building2 className="h-3 w-3 shrink-0" />}
             {chip.type === 'tenant' && <User className="h-3 w-3 shrink-0" />}
-            {chip.label}
+            <span className="truncate">{chip.label}</span>
             <button
               type="button"
               onClick={e => { e.stopPropagation(); removeChip(chip.id); }}
@@ -172,7 +172,7 @@ function SmartSearch({ chips, onChipsChange, tasks, properties, tenants }: Smart
         ))}
         <input
           ref={inputRef}
-          className="flex-1 min-w-32 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          className="flex-1 min-w-24 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
           placeholder={chips.length === 0 ? 'Search by task, tenant, or property...' : 'Add filter...'}
           value={input}
           onChange={e => { setInput(e.target.value); setOpen(true); }}
@@ -350,7 +350,7 @@ const Tasks = () => {
 
     return (
       <Card key={task.id} className={cn("px-3 py-2.5 rounded-xl hover:shadow-md transition-shadow cursor-pointer", chatPanel.isOpen && chatPanel.taskId === task.id && "ring-2 ring-primary/40")} onClick={() => navigate(`/tasks/${task.id}`)}>
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:justify-between sm:gap-2">
           <div className="flex items-center gap-1.5 flex-wrap min-w-0">
             <Badge variant="secondary" className={cn('text-[10px] rounded-lg gap-1 shrink-0', mode.className)}>
               <ModeIcon className="h-3 w-3" />
@@ -374,15 +374,15 @@ const Tasks = () => {
           <span className="text-[10px] text-muted-foreground shrink-0">{formatMessageTime(task.lastMessageAt)}</span>
         </div>
 
-        <div className="flex items-center justify-between gap-2 mt-1.5">
-          <div className="flex items-center gap-1.5 min-w-0">
+        <div className="flex flex-col gap-1 mt-1.5 sm:flex-row sm:items-center sm:justify-between sm:gap-2">
+          <div className="flex items-start gap-1.5 min-w-0">
             {task.taskNumber != null && (
-              <span className="text-[10px] font-mono text-muted-foreground shrink-0">#{task.taskNumber}</span>
+              <span className="text-[10px] font-mono text-muted-foreground shrink-0 leading-5">#{task.taskNumber}</span>
             )}
-            <h3 className="font-medium text-sm truncate">{task.title}</h3>
+            <h3 className="font-medium text-sm min-w-0 break-words sm:truncate">{task.title}</h3>
           </div>
           {property && (
-            <span className="text-[10px] text-muted-foreground shrink-0">{property.name || property.address}</span>
+            <span className="text-[10px] text-muted-foreground min-w-0 break-words sm:truncate sm:text-right">{property.name || property.address}</span>
           )}
         </div>
         {task.parentConversationId && (
@@ -424,28 +424,28 @@ const Tasks = () => {
   if (isLoading) return <PageLoader />;
 
   return (
-    <div className="p-6 max-w-4xl mx-auto space-y-5">
-      <div className="flex items-start justify-between gap-4">
+    <div className="p-4 sm:p-6 max-w-4xl mx-auto space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
         <div>
           <h1 className="text-2xl font-bold">Tasks</h1>
           <p className="text-sm text-muted-foreground">
             {activeCount} active · {needsAttentionCount} need attention
           </p>
         </div>
-        <div className="flex items-center gap-2 flex-wrap justify-end">
+        <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center sm:flex-wrap sm:justify-end">
           <MultiSelect
             options={statusOptions}
             selected={statusFilters}
             onChange={setStatusFilters}
             placeholder="All Statuses"
-            width="w-40"
+            width="w-full sm:w-40"
           />
           <MultiSelect
             options={categoryOptions}
             selected={categoryFilters}
             onChange={setCategoryFilters}
             placeholder="All Categories"
-            width="w-44"
+            width="w-full sm:w-44"
           />
         </div>
       </div>
@@ -558,17 +558,17 @@ const Tasks = () => {
             const StatusIcon = task.status === 'resolved' ? CheckCircle2 : task.status === 'cancelled' ? XCircle : PauseCircle;
             return (
               <Card key={task.id} className={cn("p-4 rounded-xl opacity-70 cursor-pointer hover:opacity-85 transition-opacity", chatPanel.isOpen && chatPanel.taskId === task.id && "ring-2 ring-primary/40 opacity-100")} onClick={() => navigate(`/tasks/${task.id}`)}>
-                <div className="flex items-start justify-between gap-3 mb-1">
-                  <div className="flex items-center gap-2">
+                <div className="flex flex-col gap-2 mb-1 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+                  <div className="flex items-start gap-2 min-w-0">
                     <StatusIcon className={cn('h-4 w-4', task.status === 'resolved' ? 'text-accent' : task.status === 'cancelled' ? 'text-destructive' : 'text-muted-foreground')} />
-                    <h3 className="font-medium text-sm">{task.title}</h3>
+                    <h3 className="font-medium text-sm min-w-0 break-words">{task.title}</h3>
                   </div>
-                  <Badge variant="secondary" className={cn('text-[10px] rounded-lg gap-1', completedMode.className)}>
+                  <Badge variant="secondary" className={cn('text-[10px] rounded-lg gap-1 w-fit shrink-0', completedMode.className)}>
                     <CompletedModeIcon className="h-3 w-3" />
                     {completedMode.label}
                   </Badge>
                 </div>
-                <p className="text-xs text-muted-foreground ml-6">{task.lastMessage}</p>
+                <p className="text-xs text-muted-foreground sm:ml-6 break-words">{task.lastMessage}</p>
               </Card>
             );
           })}

--- a/www/rentmate-ui/src/pages/Tasks.tsx
+++ b/www/rentmate-ui/src/pages/Tasks.tsx
@@ -417,6 +417,37 @@ const Tasks = () => {
             )}
           </div>
         )}
+        {task.steps && task.steps.length > 0 && (() => {
+          const doneCount = task.steps.filter(s => s.status === 'done').length;
+          const activeStep = task.steps.find(s => s.status === 'active');
+          const totalSteps = task.steps.length;
+          return (
+            <div className="mt-2">
+              <div className="flex items-center gap-0.5" aria-label={`Progress: ${doneCount} of ${totalSteps} steps complete`}>
+                {task.steps.map(step => (
+                  <div
+                    key={step.key}
+                    title={`${step.label}${step.note ? ` — ${step.note}` : ''} (${step.status})`}
+                    className={cn(
+                      'h-1 flex-1 rounded-full transition-colors',
+                      step.status === 'done' && 'bg-primary',
+                      step.status === 'active' && 'bg-primary/60 animate-pulse',
+                      step.status === 'pending' && 'bg-muted',
+                    )}
+                  />
+                ))}
+              </div>
+              <div className="mt-1 flex items-center justify-between text-[9px] text-muted-foreground">
+                <span className="min-w-0 truncate">
+                  {doneCount}/{totalSteps} steps
+                  {activeStep && (
+                    <span className="text-foreground/80"> · {activeStep.label}</span>
+                  )}
+                </span>
+              </div>
+            </div>
+          );
+        })()}
       </Card>
     );
   };

--- a/www/rentmate-ui/src/pages/task-detail-conversation-switch.test.tsx
+++ b/www/rentmate-ui/src/pages/task-detail-conversation-switch.test.tsx
@@ -247,6 +247,28 @@ describe('TaskDetail conversation switching', () => {
     });
   });
 
+  it('renders mobile tabs for the task detail panes in dashboard order', async () => {
+    const task = makeTask();
+    appStore.setState(makeAppState(task));
+
+    render(
+      <MemoryRouter initialEntries={['/tasks/task-1']} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Routes>
+          <Route path="/tasks/:id" element={<TaskDetail />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('AI thread ready')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('task-detail-tab-list')).toHaveTextContent('Chat List');
+    expect(screen.getByTestId('task-detail-tab-chat')).toHaveTextContent('Chat');
+    expect(screen.getByTestId('task-detail-tab-task')).toHaveTextContent('Task');
+    expect(screen.getByTestId('task-detail-tab-chat')).toHaveAttribute('aria-pressed', 'true');
+  });
+
   it('lets the manager switch from tenant chat back to the AI thread', async () => {
     const task = makeTask();
     appStore.setState(makeAppState(task));
@@ -268,7 +290,7 @@ describe('TaskDetail conversation switching', () => {
       expect(screen.getByText('Hi from tenant')).toBeInTheDocument();
     });
 
-    const leftRail = container.querySelector('div.grid > aside');
+    const leftRail = container.querySelector('aside');
     expect(leftRail).toBeTruthy();
     const rentMateBadges = within(leftRail as HTMLElement).getAllByText('RentMate');
     fireEvent.click(rentMateBadges[0]);
@@ -381,7 +403,7 @@ describe('TaskDetail conversation switching', () => {
       expect(screen.getByText('Hi from tenant')).toBeInTheDocument();
     });
 
-    const leftRail = container.querySelector('div.grid > aside');
+    const leftRail = container.querySelector('aside');
     expect(leftRail).toBeTruthy();
     const rentMateBadges = within(leftRail as HTMLElement).getAllByText('RentMate');
     fireEvent.click(rentMateBadges[0]);
@@ -430,7 +452,7 @@ describe('TaskDetail conversation switching', () => {
       expect(screen.getByText('Hi from tenant')).toBeInTheDocument();
     });
 
-    const leftRail = container.querySelector('div.grid > aside');
+    const leftRail = container.querySelector('aside');
     expect(leftRail).toBeTruthy();
     const rentMateBadges = within(leftRail as HTMLElement).getAllByText('RentMate');
     fireEvent.click(rentMateBadges[0]);


### PR DESCRIPTION
## Summary
- Make the Tasks page header and filters stack cleanly on narrow screens
- Let task titles, property labels, chips, and completed cards wrap instead of squeezing/overflowing
- Preserve the desktop layout at the existing sm breakpoint

## Tests
- npx tsc --noEmit
- npm --prefix www/rentmate-ui run build