### PR TITLE
Use RentMate icon in generated documents

### DIFF
--- a/llm/tools/doc_gen/generated_documents.py
+++ b/llm/tools/doc_gen/generated_documents.py
@@ -17,6 +17,16 @@ class RenderedDocument:
     renderer: str
 
 
+_RENTMATE_ICON_SVG = """
+<svg class="brand-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-hidden="true" role="img">
+  <rect width="64" height="64" rx="14" fill="#2680D9"/>
+  <path fill="#ffffff" d="M32 13 L12 30 L12 33 L15 33 L15 51 L27 51 L27 38 L37 38 L37 51 L49 51 L49 33 L52 33 L52 30 Z"/>
+  <circle cx="48" cy="18" r="6" fill="#ffffff"/>
+  <circle cx="48" cy="18" r="3.5" fill="#2680D9"/>
+</svg>
+""".strip()
+
+
 def _normalize_whitespace(value: str) -> str:
     return value.replace("\r\n", "\n").replace("\r", "\n")
 
@@ -117,14 +127,15 @@ def _build_html_document(*, title: str, body_html: str) -> str:
               .brand-mark {{
                 width: 24px;
                 height: 24px;
-                border: 1px solid var(--rm-line);
-                background: var(--rm-soft);
                 display: inline-flex;
                 align-items: center;
                 justify-content: center;
-                font-weight: 700;
-                font-size: 10px;
-                letter-spacing: 0.08em;
+              }}
+
+              .brand-icon {{
+                width: 24px;
+                height: 24px;
+                display: block;
               }}
 
               .brand-name {{
@@ -217,7 +228,7 @@ def _build_html_document(*, title: str, body_html: str) -> str:
           </head>
           <body>
             <header>
-              <span class="brand-mark" aria-hidden="true">RM</span>
+              <span class="brand-mark">{_RENTMATE_ICON_SVG}</span>
               <span class="brand-name">RentMate</span>
             </header>
             <main>

--- a/llm/tools/doc_gen/tests/test_generated_documents.py
+++ b/llm/tools/doc_gen/tests/test_generated_documents.py
@@ -28,6 +28,8 @@ def test_render_document_wraps_html_and_returns_pdf_bytes():
     assert "<title>14-Day Notice</title>" in rendered.html
     assert "Prepared By RentMate" in rendered.html
     assert "RentMate" in rendered.html
+    assert '<svg class="brand-icon"' in rendered.html
+    assert 'fill="#2680D9"' in rendered.html
     assert "<h2>Notice</h2>" in rendered.html
 
 


### PR DESCRIPTION
## Summary
- Replace the generated document text badge with the same RentMate house/chat icon used by the favicon
- Keep the icon inline in generated document HTML so WeasyPrint can render it without external assets
- Add generated-document template coverage for the brand icon

## Verification
- poetry run pytest llm/tools/doc_gen/tests/test_generated_documents.py -q
- poetry run python -m compileall llm/tools/doc_gen/generated_documents.py
- poetry run python - <<'PY'
from llm.tools.doc_gen.generated_documents import render_document
r = render_document(title='Icon Smoke', text_content='Tenant: Example')
assert '<svg class="brand-icon"' in r.html
assert r.pdf_bytes.startswith(b'%PDF-')
print(len(r.pdf_bytes))
PY